### PR TITLE
Don't remove and rebuild images based on creation date

### DIFF
--- a/swebench/harness/docker_build.py
+++ b/swebench/harness/docker_build.py
@@ -236,14 +236,6 @@ def get_env_configs_to_build(
         try:
             env_image = client.images.get(test_spec.env_image_key)
             image_exists = True
-
-            if env_image.attrs["Created"] < base_image.attrs["Created"]:
-                # Remove the environment image if it was built after the base_image
-                for dep in find_dependent_images(client, test_spec.env_image_key):
-                    # Remove instance images that depend on this environment image
-                    remove_image(client, dep.image_id, "quiet")
-                remove_image(client, test_spec.env_image_key, "quiet")
-                image_exists = False
         except docker.errors.ImageNotFound:
             pass
         if not image_exists:
@@ -451,12 +443,7 @@ def build_instance_image(
     image_exists = False
     try:
         instance_image = client.images.get(image_name)
-        if instance_image.attrs["Created"] < env_image.attrs["Created"]:
-            # the environment image is newer than the instance image, meaning the instance image may be outdated
-            remove_image(client, image_name, "quiet")
-            image_exists = False
-        else:
-            image_exists = True
+        image_exists = True
     except docker.errors.ImageNotFound:
         pass
 


### PR DESCRIPTION
#### Reference Issues/PRs
(No references, this is self-contained)

#### What does this implement/fix? Explain your changes.
The [current behavior](https://github.com/princeton-nlp/SWE-bench/blob/main/swebench/harness/docker_build.py#L454) of the SWEB harness is to rebuild images if the instance/env image's creation date is older than the env/base image's creation date. This sounds like a sensible and helpful feature, except if you consider the following workflow:

On my team we find it useful to share images with each other, for example it is useful to build once and upload env or instance images to Dockerhub, so that others can skip the build step completely and just download an image with 100% guarantee that the environment is identical. In this setup, the downloaded images have a creation date that may be some weeks old, while I might have a base image on my local machine which was built more recently. But the base image in this case is irrelevant, and I just want to use the image I've downloaded. In this scenario, if I try to run the harness, the creation date feature blocks me from being able to use my downloaded image, and the harness always forces a rebuild.

Furthermore, [this print statement](https://github.com/princeton-nlp/SWE-bench/blob/main/swebench/harness/run_evaluation.py#L254) even tells the user `Found {len(existing_images)} existing instance images. Will reuse them.`, but it might later still silently rebuild the images without the user knowing. This has caused some confusion more than once!

Overall, I think it would be cleaner to remove this behavior which makes it harder to reason about rebuilds and caching images. We can leave it to the user's responsibility to make sure their images are up-to-date.

So this PR is both an ask and a proposed implementation to remove the "rebuild if image is older" feature.

#### Any other comments?

If there is a strong preference to keep the feature, I think we should at least fix the part where this happens silently - the user should know if their images are being skipped and rebuilt.

Thank you!