### PR TITLE
Fix: Skip invalid log lines in pytest_v2 log parser.

### DIFF
--- a/swebench/harness/log_parsers.py
+++ b/swebench/harness/log_parsers.py
@@ -151,11 +151,13 @@ def parse_log_pytest_v2(log: str) -> dict[str, str]:
             if line.startswith(TestStatus.FAILED.value):
                 line = line.replace(" - ", " ")
             test_case = line.split()
-            test_status_map[test_case[1]] = test_case[0]
+            if len(test_case) >= 2:
+                test_status_map[test_case[1]] = test_case[0]
         # Support older pytest versions by checking if the line ends with the test status
         elif any([line.endswith(x.value) for x in TestStatus]):
             test_case = line.split()
-            test_status_map[test_case[0]] = test_case[1]
+            if len(test_case) >= 2:
+                test_status_map[test_case[0]] = test_case[1]
     return test_status_map
 
 


### PR DESCRIPTION
### Description

This pull request addresses an `IndexError` encountered in the `parse_log_pytest_v2` function within the `log_parsers.py` file. The error occurred when the function attempted to access an index in the `test_case` list that did not exist, specifically when processing invalid log lines.

### Changes Made

- Added a conditional check to ensure that the `test_case` list has the expected length before attempting to access its elements. This prevents the `IndexError` by skipping over log lines that do not conform to the expected format.

### Error Log

The error was observed with the following log entry:

```
2024-12-04 23:58:13,842 - ERROR - Error in evaluating model for astropy__astropy-14995: list index out of range
Traceback (most recent call last):
  ...
  File "/home/barty/miniconda3/lib/python3.12/site-packages/swebench/harness/log_parsers.py", line 158, in parse_log_pytest_v2
    test_status_map[test_case[0]] = test_case[1]
                                    ~~~~~~~~~^^^
IndexError: list index out of range
```

### Impact

This fix improves the robustness of the log parser by ensuring it can handle unexpected log formats without crashing, thereby enhancing the overall stability of the evaluation process.