### PR TITLE
fix flask dependencies

### DIFF
--- a/swebench/harness/constants.py
+++ b/swebench/harness/constants.py
@@ -105,6 +105,7 @@ SPECS_FLASK = {
         "packages": "requirements.txt",
         "install": "python -m pip install -e .",
         "pip_packages": [
+            "setuptools==70.0.0",
             "click==8.1.3",
             "itsdangerous==2.1.2",
             "Jinja2==3.1.2",
@@ -121,6 +122,7 @@ SPECS_FLASK.update(
             "packages": "requirements.txt",
             "install": "python -m pip install -e .",
             "pip_packages": [
+                "setuptools==70.0.0",
                 "click==8.1.3",
                 "itsdangerous==2.1.2",
                 "Jinja2==3.1.2",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
Fixes #271 

#### What does this implement/fix? Explain your changes.
downgrade setuptools requirement to avoid build failures

#### Any other comments?
Tested changes on all flask problems with
```
python -m swebench.harness.run_evaluation --predictions_path gold --max_workers 1 --dataset princeton-nlp/SWE-bench --run_id gold --cache_level instance --instance_ids pallets__flask-4045 pallets__flask-4074 pallets__flask-4160 pallets__flask-4169 pallets__flask-4544 pallets__flask-4575 pallets__flask-4642 pallets__flask-4935 pallets__flask-4992 pallets__flask-5014 pallets__flask-5063
```

All images build and all instances are resolved with gold patch:
```
Total instances: 11
Instances submitted: 11
Instances completed: 11
Instances incomplete: 0
Instances resolved: 11
Instances unresolved: 0
Instances with empty patches: 0
Instances with errors: 0
Unstopped containers: 0
Unremoved images: 11
```
