### PR TITLE
Fix sympy version for specific instance

### DIFF
--- a/swebench/harness/docker_build.py
+++ b/swebench/harness/docker_build.py
@@ -453,6 +453,9 @@ def build_instance_image(
 
     # Build the instance image
     if not image_exists:
+        # Check for specific instance ID and install specific version of antlr4-python3-runtime
+        if test_spec.instance_id == "sympy__sympy-21612":
+            test_spec.repo_script_list.append("python -m pip install antlr4-python3-runtime==4.7.2")
         build_image(
             image_name=image_name,
             setup_scripts={


### PR DESCRIPTION
Fixes #265

Modify the `build_instance_image` function in `swebench/harness/docker_build.py` to check for the instance ID `sympy__sympy-21612` and install `antlr4-python3-runtime==4.7.2` if it matches.

* Add a check for the specific instance ID `sympy__sympy-21612`
* Append the installation command for `antlr4-python3-runtime==4.7.2` to the `repo_script_list` if the instance ID matches

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/swe-bench/SWE-bench/pull/273?shareId=c3733cbb-595d-44af-9dae-7c4a75be3f37).