### PR TITLE
Avoid breaking apart testcase name when they contain spaces

### DIFF
--- a/swebench/harness/log_parsers/python.py
+++ b/swebench/harness/log_parsers/python.py
@@ -153,13 +153,11 @@ def parse_log_pytest_v2(log: str, test_spec: TestSpec) -> dict[str, str]:
             if line.startswith(TestStatus.FAILED.value):
                 line = line.replace(" - ", " ")
             test_case = line.split()
-            if len(test_case) >= 2:
-                test_status_map[test_case[1]] = test_case[0]
+            test_status_map[" ".join(test_case[1:])] = test_case[0]
         # Support older pytest versions by checking if the line ends with the test status
         elif any([line.endswith(x.value) for x in TestStatus]):
             test_case = line.split()
-            if len(test_case) >= 2:
-                test_status_map[test_case[1]] = test_case[0]
+            test_status_map[" ".join(test_case[:-1])] = test_case[-1]
     return test_status_map
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
This could be related to what @WuYff observed in SWE-bench/swe-bench-dockerfiles#16. In any case, this impacts the current HuggingFace dataset, eg. https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified/viewer/default/test?row=7

#### What does this implement/fix? Explain your changes.
The function [`parse_log_pytest_v2(log: str)`](https://github.com/swe-bench/SWE-bench/blob/main/swebench/harness/log_parsers.py#L153-L155) produces truncated testcase names when they contain spaces in them, eg. 
```bash
PASSED astropy/coordinates/tests/test_sky_coord.py::test_passing_inconsistent_coordinates_and_units_raises_helpful_error[kwargs0-Unit 'deg' \\(angle\\) could not be applied to 'distance'. ]
```
This PR fixes that issue.

#### Minimal reproducible example
```python
from swebench.harness.log_parsers import parse_log_pytest_v2
result = parse_log_pytest_v2("PASSED astropy/coordinates/tests/test_sky_coord.py::test_passing_inconsistent_coordinates_and_units_raises_helpful_error[kwargs0-Unit 'deg' \\(angle\\) could not be applied to 'distance'. ]")
print(result)
```
> {'astropy/coordinates/tests/test_sky_coord.py::test_passing_inconsistent_coordinates_and_units_raises_helpful_error[kwargs0-Unit': 'PASSED'}

after the fix

> {"astropy/coordinates/tests/test_sky_coord.py::test_passing_inconsistent_coordinates_and_units_raises_helpful_error[kwargs0-Unit 'deg' \\(angle\\) could not be applied to 'distance'. ]": 'PASSED'}