### PR TITLE
Update swe-bench to build for metr pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,3 +141,13 @@ If you find our work helpful, please use the following citations.
 
 ## 🪪 License
 MIT. Check `LICENSE.md`.
+
+# Build Docker Images to Docker Hub
+
+1. First, setup the docker hub cloud builder
+2. Then:
+```
+docker login
+docker buildx use cloud-metrevals-vivaria
+python swebench/harness/prepare_images.py
+```

--- a/swebench/harness/dockerfiles.py
+++ b/swebench/harness/dockerfiles.py
@@ -33,7 +33,7 @@ RUN conda config --append channels conda-forge
 RUN adduser --disabled-password --gecos 'dog' nonroot
 """
 
-_DOCKERFILE_ENV = r"""FROM --platform={platform} sweb.base.{arch}:latest
+_DOCKERFILE_ENV = r"""FROM --platform={platform} metrevals/swebench:sweb.base.{arch}
 
 COPY ./setup_env.sh /root/
 RUN sed -i -e 's/\r$//' /root/setup_env.sh

--- a/swebench/harness/prepare_images.py
+++ b/swebench/harness/prepare_images.py
@@ -90,7 +90,7 @@ def main(
 
 if __name__ == "__main__":
     parser = ArgumentParser()
-    parser.add_argument("--dataset_name", type=str, default="princeton-nlp/SWE-bench_Lite", help="Name of the dataset to use")
+    parser.add_argument("--dataset_name", type=str, default="princeton-nlp/SWE-bench_Verified", help="Name of the dataset to use")
     parser.add_argument("--split", type=str, default="test", help="Split to use")
     parser.add_argument("--instance_ids", nargs="+", type=str, help="Instance IDs to run (space separated)")
     parser.add_argument("--max_workers", type=int, default=4, help="Max workers for parallel processing")

--- a/swebench/harness/test_spec.py
+++ b/swebench/harness/test_spec.py
@@ -62,7 +62,7 @@ class TestSpec:
 
     @property
     def base_image_key(self):
-        return f"sweb.base.{self.arch}:latest"
+        return f"metrevals/swebench:sweb.base.{self.arch}"
 
     @property
     def env_image_key(self):
@@ -76,11 +76,11 @@ class TestSpec:
         hash_object.update(str(self.env_script_list).encode(UTF8))
         hash_value = hash_object.hexdigest()
         val = hash_value[:22]  # 22 characters is still very likely to be unique
-        return f"sweb.env.{self.arch}.{val}:latest"
+        return f"metrevals/swebench:sweb.env.{self.arch}.{val}"
 
     @property
     def instance_image_key(self):
-        return f"sweb.eval.{self.arch}.{self.instance_id}:latest"
+        return f"metrevals/swebench:sweb.eval.{self.arch}.{self.instance_id}"
 
     def get_instance_container_name(self, run_id=None):
         if not run_id:
@@ -316,6 +316,8 @@ def make_test_spec(instance: SWEbenchInstance) -> TestSpec:
         arch = "arm64" if instance_id not in USE_X86 else "x86_64"
     else:
         arch = "x86_64"
+
+    arch = "x86_64"
 
     return TestSpec(
         instance_id=instance_id,


### PR DESCRIPTION
# Makes it so we can build swe-bench for our docker hub

Ideally, we'd refactor this to:
1. Work without METR
2. Make the `repo` param optional (perhaps)
3. Make the `--push` flag optional

All of these would be reasonable refactors we probably could get rebased into the main swe-bench repo (so we don't have to maintain this ourselves), but let's not do it now.