### PR TITLE
Replace `modal.Mount(` with suggested fix

### DIFF
--- a/swebench/harness/modal_eval/run_evaluation_modal.py
+++ b/swebench/harness/modal_eval/run_evaluation_modal.py
@@ -71,15 +71,12 @@ class ModalSandboxRuntime:
             timeout = 60 * 30
 
         return modal.Sandbox.create(
-            image=self.image,
+            image=self.image.add_local_file(
+                REMOTE_SANDBOX_ENTRYPOINT_PATH,
+                REMOTE_SANDBOX_ENTRYPOINT_PATH,
+            ),
             timeout=timeout,
             cpu=4,
-            mounts=[
-                self.image.add_local_file(
-                    REMOTE_SANDBOX_ENTRYPOINT_PATH,
-                    REMOTE_SANDBOX_ENTRYPOINT_PATH,
-                )
-            ],
         )
     
     async def _read_stream(self, stream: modal.io_streams.StreamReader, output_list: list[str]):
@@ -303,13 +300,10 @@ def get_log_dir(pred: dict, run_id: str, instance_id: str) -> Path:
     return RUN_EVALUATION_LOG_DIR / run_id / model_name_or_path / instance_id
 
 @app.function(
-    image=swebench_image,
-    mounts=[
-        swebench_image.add_local_file(
-            LOCAL_SANDBOX_ENTRYPOINT_PATH,
-            REMOTE_SANDBOX_ENTRYPOINT_PATH,
-        )
-    ],
+    image=swebench_image.add_local_file(
+        LOCAL_SANDBOX_ENTRYPOINT_PATH,
+        REMOTE_SANDBOX_ENTRYPOINT_PATH,
+    ),
     timeout=120*60, # Much larger than default timeout to account for image build time
 )
 def run_instance_modal(

--- a/swebench/harness/modal_eval/run_evaluation_modal.py
+++ b/swebench/harness/modal_eval/run_evaluation_modal.py
@@ -75,7 +75,7 @@ class ModalSandboxRuntime:
             timeout=timeout,
             cpu=4,
             mounts=[
-                modal.Mount.from_local_file(
+                self.image.add_local_file(
                     REMOTE_SANDBOX_ENTRYPOINT_PATH,
                     REMOTE_SANDBOX_ENTRYPOINT_PATH,
                 )
@@ -305,7 +305,7 @@ def get_log_dir(pred: dict, run_id: str, instance_id: str) -> Path:
 @app.function(
     image=swebench_image,
     mounts=[
-        modal.Mount.from_local_file(
+        swebench_image.add_local_file(
             LOCAL_SANDBOX_ENTRYPOINT_PATH,
             REMOTE_SANDBOX_ENTRYPOINT_PATH,
         )


### PR DESCRIPTION
@azliu0 and the Modal team, I'm seeing a `PendingDeprecationError` due to the use of `modal.Mount`

![Screenshot 2025-01-15 at 2 46 50 PM](https://github.com/user-attachments/assets/50825749-370c-43d5-b320-64d9f26203db)

I have replaced the invocations with the suggested fix displayed in the error message. I ran evaluation with and without modal, and it seems to work fine, but just thought I'd run it by your team to make sure this looks okay.

Thanks!