### PR TITLE
Fix: remove a duplicate code block to prevent unexpected exit from empty `dataset` when using Modal

### DIFF
--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -550,15 +550,6 @@ def main(
     predictions = get_predictions_from_file(predictions_path, dataset_name, split)
     predictions = {pred[KEY_INSTANCE_ID]: pred for pred in predictions}
 
-    if modal:
-        # run instances on Modal
-        if not dataset:
-            print("No instances to run.")
-        else:
-            validate_modal_credentials()
-            run_instances_modal(predictions, dataset, full_dataset, run_id, timeout)
-        return
-
     # get dataset from predictions
     dataset = get_dataset_from_preds(dataset_name, split, instance_ids, predictions, run_id, rewrite_reports)
     full_dataset = load_swebench_dataset(dataset_name, split, instance_ids)


### PR DESCRIPTION


<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
None

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->

There are two same code blocks below in `run_evaluation.py`. The first one uses `dataset` before assignment.
```python
if modal:
    # run instances on Modal
    if not dataset:
        print("No instances to run.")
    else:
        validate_modal_credentials()
        run_instances_modal(predictions, dataset, full_dataset, run_id, timeout)
    return
```

#### Any other comments?

🧡 Thanks for contributing!
