### PR TITLE
Fix: Cast empty string namespace to None

### DIFF
--- a/swebench/__init__.py
+++ b/swebench/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.6"
+__version__ = "3.0.7"
 
 from swebench.collect.build_dataset import main as build_dataset
 from swebench.collect.get_tasks_pipeline import main as get_tasks_pipeline

--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -411,6 +411,8 @@ def main(
     """
     Run evaluation harness for the given dataset and predictions.
     """
+    namespace = None if namespace == "" else namespace
+    
     if dataset_name == "princeton-nlp/SWE-bench_Multimodal" and split == "test":
         print(
             "⚠️ Local evaluation for the test split of SWE-bench Multimodal is not supported. "


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
This lets user pass no namespace to force a local build for swebench.harness.run_evaluation, which currently is not possible.
Fixes #316 for instance, where the user needs to build locally for the evaluation to work but can't.

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->
We keep the swebench default value for the namespace argument, but we cast empty strings to None.