### PR TITLE
Add one PHP instance

### DIFF
--- a/swebench/harness/constants/__init__.py
+++ b/swebench/harness/constants/__init__.py
@@ -1,19 +1,23 @@
 from swebench.harness.constants.constants import *
 from swebench.harness.constants.javascript import *
+from swebench.harness.constants.php import *
 from swebench.harness.constants.python import *
 
 MAP_REPO_VERSION_TO_SPECS = {
     **MAP_REPO_VERSION_TO_SPECS_JS,
+    **MAP_REPO_VERSION_TO_SPECS_PHP,
     **MAP_REPO_VERSION_TO_SPECS_PY,
 }
 
 MAP_REPO_TO_INSTALL = {
     **MAP_REPO_TO_INSTALL_JS,
+    **MAP_REPO_TO_INSTALL_PHP,
     **MAP_REPO_TO_INSTALL_PY,
 }
 
 MAP_REPO_TO_EXT = {
     **{k: "js" for k in MAP_REPO_VERSION_TO_SPECS_JS.keys()},
+    **{k: "php" for k in MAP_REPO_VERSION_TO_SPECS_PHP.keys()},
     **{k: "py" for k in MAP_REPO_VERSION_TO_SPECS_PY.keys()},
 }
 

--- a/swebench/harness/constants/php.py
+++ b/swebench/harness/constants/php.py
@@ -1,0 +1,18 @@
+# Constants - Task Instance Installation Environment
+SPECS_PHPSPREADSHEET = {
+    "4313": {
+        "docker_specs": { "php_version": "8.3.16" },
+        "base_docker_specs": { "php_version": "8.3.16" },
+        "install": ["composer update", "composer install"],
+        "test_cmd": [
+            "./vendor/bin/phpunit --testdox --colors=never tests/PhpSpreadsheetTests/Writer/Ods/IndentTest.php"
+        ],
+    }
+}
+
+MAP_REPO_VERSION_TO_SPECS_PHP = {
+    "phpoffice/phpspreadsheet": SPECS_PHPSPREADSHEET,
+}
+
+# Constants - Repository Specific Installation Instructions
+MAP_REPO_TO_INSTALL_PHP = {}

--- a/swebench/harness/dockerfiles/__init__.py
+++ b/swebench/harness/dockerfiles/__init__.py
@@ -10,9 +10,15 @@ from swebench.harness.dockerfiles.python import (
     _DOCKERFILE_INSTANCE_PY,
 )
 
+from swebench.harness.dockerfiles.php import (
+    _DOCKERFILE_BASE_PHP,
+    _DOCKERFILE_INSTANCE_PHP,
+)
+
 _DOCKERFILE_BASE = {
     "py": _DOCKERFILE_BASE_PY,
     "js": _DOCKERFILE_BASE_JS,
+    "php": _DOCKERFILE_BASE_PHP,
 }
 
 _DOCKERFILE_ENV = {
@@ -23,25 +29,36 @@ _DOCKERFILE_ENV = {
 _DOCKERFILE_INSTANCE = {
     "py": _DOCKERFILE_INSTANCE_PY,
     "js": _DOCKERFILE_INSTANCE_JS,
+    "php": _DOCKERFILE_INSTANCE_PHP,
 }
 
-def get_dockerfile_base(platform, arch, language):
+def get_dockerfile_base(platform, arch, language, **kwargs):
     if arch == "arm64":
         conda_arch = "aarch64"
     else:
         conda_arch = arch
     return _DOCKERFILE_BASE[language].format(
         platform=platform,
-        conda_arch=conda_arch
+        conda_arch=conda_arch,
+        **kwargs
     )
 
 
 def get_dockerfile_env(platform, arch, language, **kwargs):
-    return _DOCKERFILE_ENV[language].format(
-        platform=platform,
-        arch=arch,
-        **kwargs
-    )
+    # Some languages do not have an environment Dockerfile. In those cases, the
+    # base Dockerfile is used as the environment Dockerfile.
+    if language in _DOCKERFILE_ENV:
+        return _DOCKERFILE_ENV[language].format(
+            platform=platform,
+            arch=arch,
+            **kwargs
+        )
+    else:
+        return _DOCKERFILE_BASE[language].format(
+            platform=platform,
+            arch=arch,
+            **kwargs
+        )
 
 
 def get_dockerfile_instance(platform, language, env_image_name):

--- a/swebench/harness/dockerfiles/php.py
+++ b/swebench/harness/dockerfiles/php.py
@@ -1,0 +1,33 @@
+_DOCKERFILE_BASE_PHP = r"""
+FROM --platform={platform} php:{php_version}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+
+RUN apt update && apt install -y \
+    wget \
+    git \
+    build-essential \
+    libgd-dev \
+    libzip-dev \
+    libgmp-dev \
+    libftp-dev \
+    && apt-get -y autoclean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN docker-php-ext-install gd zip gmp ftp
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+RUN adduser --disabled-password --gecos 'dog' nonroot
+"""
+
+# No env image for PHP. The base image is used as the environment image since it configures the PHP environment
+
+_DOCKERFILE_INSTANCE_PHP = r"""FROM --platform={platform} {env_image_name}
+
+COPY ./setup_repo.sh /root/
+RUN /bin/bash /root/setup_repo.sh
+
+WORKDIR /testbed/
+"""

--- a/swebench/harness/log_parsers/__init__.py
+++ b/swebench/harness/log_parsers/__init__.py
@@ -1,8 +1,10 @@
 from swebench.harness.log_parsers.javascript import MAP_REPO_TO_PARSER_JS
+from swebench.harness.log_parsers.php import MAP_REPO_TO_PARSER_PHP
 from swebench.harness.log_parsers.python import MAP_REPO_TO_PARSER_PY
 from swebench.harness.log_parsers.utils import get_eval_type
 
 MAP_REPO_TO_PARSER = {
     **MAP_REPO_TO_PARSER_JS,
+    **MAP_REPO_TO_PARSER_PHP,
     **MAP_REPO_TO_PARSER_PY,
 }

--- a/swebench/harness/log_parsers/php.py
+++ b/swebench/harness/log_parsers/php.py
@@ -1,0 +1,42 @@
+import re
+from swebench.harness.constants.constants import TestStatus
+from swebench.harness.test_spec.test_spec import TestSpec
+
+def parse_log_phpunit(log: str, test_spec: TestSpec) -> dict[str, str]:
+    """
+    Parser for phpunit logs with the --testdox option.
+    Args:
+        log (str): log content
+        test_spec (TestSpec): test spec (unused)
+    Returns:
+        dict: test case to test status mapping
+    """
+    test_status_map = {}
+    suite = None
+
+    suite_pattern = r"^(\w.+) \(.+\)$"
+    test_pattern = r"^\s*([✔✘↩])\s*(.*)$"
+
+    for line in log.split("\n"):
+        suite_match = re.match(suite_pattern, line)
+        if suite_match:
+            suite = suite_match.groups()[0]
+            continue
+
+        test_match = re.match(test_pattern, line)
+        if test_match:
+            status, test_name = test_match.groups()
+            full_test_name = f"{suite} > {test_name}"
+
+            if status == "✔":
+                test_status_map[full_test_name] = TestStatus.PASSED.value
+            elif status == "✘":
+                test_status_map[full_test_name] = TestStatus.FAILED.value
+            elif status == "↩":
+                test_status_map[full_test_name] = TestStatus.SKIPPED.value
+
+    return test_status_map
+
+MAP_REPO_TO_PARSER_PHP = {
+    "phpoffice/phpspreadsheet": parse_log_phpunit,
+}

--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -56,6 +56,7 @@ from swebench.harness.utils import (
     get_predictions_from_file,
     run_threadpool,
     str2bool,
+    str_or_none,
 )
 
 GIT_APPLY_CMDS = [
@@ -123,7 +124,7 @@ def run_instance(
             except:
                 # some error, idk why
                 pass
-    
+
     # Set up logger
     log_dir.mkdir(parents=True, exist_ok=True)
     log_file = log_dir / LOG_INSTANCE
@@ -299,7 +300,7 @@ def run_instances(
             timeout,
             rewrite_reports,
         ))
-    
+
     # run instances in parallel
     print(f"Running {len(instances)} instances...")
     run_threadpool(run_instance, payloads, max_workers)
@@ -329,7 +330,7 @@ def get_dataset_from_preds(
         missing_preds = set(instance_ids) - set(predictions.keys())
         if missing_preds:
             print(f"Warning: Missing predictions for {len(missing_preds)} instance IDs.")
-    
+
     # check that all prediction IDs are in the dataset
     prediction_ids = set(predictions.keys())
     if prediction_ids - dataset_ids:
@@ -360,7 +361,7 @@ def get_dataset_from_preds(
                 test_output_ids.add(instance[KEY_INSTANCE_ID])
         dataset = [i for i in dataset if i[KEY_INSTANCE_ID] in prediction_ids and i[KEY_INSTANCE_ID] in test_output_ids]
         return dataset
-    
+
     # check which instance IDs have already been run
     completed_ids = set()
     for instance in dataset:
@@ -486,7 +487,7 @@ if __name__ == "__main__":
     # Common args
     parser.add_argument("--dataset_name", default="princeton-nlp/SWE-bench_Lite", type=str, help="Name of dataset or path to JSON file.")
     parser.add_argument("--split", type=str, default="test", help="Split of the dataset")
-    parser.add_argument( "--instance_ids", nargs="+", type=str, help="Instance IDs to run (space separated)")
+    parser.add_argument("--instance_ids", nargs="+", type=str, help="Instance IDs to run (space separated)")
     parser.add_argument("--predictions_path", type=str, help="Path to predictions file - if 'gold', uses gold predictions", required=True)
 
     # Local execution args
@@ -499,7 +500,7 @@ if __name__ == "__main__":
     # if clean is false, we only remove images above the cache level if they don't already exist
     parser.add_argument("--clean", type=str2bool, default=False, help="Clean images above cache level")
     parser.add_argument("--run_id", type=str, required=True, help="Run ID - identifies the run")
-    parser.add_argument("--namespace", type=str, default="swebench", help="Namespace for images")
+    parser.add_argument("--namespace", type=str_or_none, default="swebench", help="Namespace for images. Use 'none' to disable namespace for images to be built locally")
     parser.add_argument("--instance_image_tag", type=str, default='latest', help="Instance image tag")
     parser.add_argument("--rewrite_reports", type=str2bool, default=False, help="Doesn't run new instances, only writes reports for instances with existing test outputs")
     parser.add_argument("--report_dir", type=str, default=".", help="Directory to write reports to")

--- a/swebench/harness/test_spec/common.py
+++ b/swebench/harness/test_spec/common.py
@@ -1,0 +1,81 @@
+from swebench.harness.constants import (
+    END_TEST_OUTPUT,
+    MAP_REPO_VERSION_TO_SPECS,
+    START_TEST_OUTPUT,
+)
+from swebench.harness.utils import get_modified_files
+
+
+# MARK: Test Command Creation Functions
+
+def get_test_cmds(instance) -> list:
+    test_cmd = MAP_REPO_VERSION_TO_SPECS[instance["repo"]][instance["version"]]["test_cmd"]
+    return [test_cmd] if isinstance(test_cmd, str) else test_cmd
+
+
+# MARK: Script Creation Functions
+
+def make_repo_script_list_common(specs, repo, repo_directory, base_commit, env_name) -> list:
+    """
+    Create a list of bash commands to set up the repository for testing.
+    This is the setup script for the instance image.
+    """
+    setup_commands = [
+        f"git clone -o origin https://github.com/{repo} {repo_directory}",
+        f"cd {repo_directory}",
+        f"git reset --hard {base_commit}",
+        f"chmod -R 777 {repo_directory}",  # So nonroot user can run tests
+        # Remove the remote so the agent won't see newer commits.
+        f"git remote remove origin",
+    ]
+    if "install" in specs:
+        setup_commands.extend(specs["install"])
+    return setup_commands
+
+
+def make_env_script_list_common(instance, specs, env_name) -> list:
+    """
+    Creates the list of commands to set up the environment for testing.
+    This is the setup script for the environment image.
+    """
+    reqs_commands = []
+    if "apt-pkgs" in specs:
+        reqs_commands += [
+            "apt-get update",
+            f"apt-get install -y {' '.join(specs['apt-pkgs'])}"
+        ]
+    return reqs_commands
+
+
+def make_eval_script_list_common(instance, specs, env_name, repo_directory, base_commit, test_patch) -> list:
+    """
+    Applies the test patch and runs the tests.
+    """
+    HEREDOC_DELIMITER = "EOF_114329324912"
+    test_files = get_modified_files(test_patch)
+    # Reset test files to the state they should be in before the patch.
+    if test_files:
+        reset_tests_command = f"git checkout {base_commit} {' '.join(test_files)}"
+    else:
+        reset_tests_command = f'echo "No test files to reset"'
+
+    apply_test_patch_command = (
+        f"git apply --verbose --reject - <<'{HEREDOC_DELIMITER}'\n{test_patch}\n{HEREDOC_DELIMITER}"
+    )
+    test_commands = get_test_cmds(instance)
+    eval_commands = [
+        f"cd {repo_directory}",
+        f"git config --global --add safe.directory {repo_directory}",  # for nonroot user
+        f"cd {repo_directory}",
+        # This is just informational, so we have a record
+        # f"git status",
+        # f"git show",
+        # f"git -c core.fileMode=false diff {base_commit}",
+        reset_tests_command,
+        apply_test_patch_command,
+        f": '{START_TEST_OUTPUT}'",
+        *test_commands,
+        f": '{END_TEST_OUTPUT}'",
+        reset_tests_command,
+    ]
+    return eval_commands

--- a/swebench/harness/test_spec/create_scripts.py
+++ b/swebench/harness/test_spec/create_scripts.py
@@ -3,6 +3,11 @@ from swebench.harness.test_spec.javascript import (
     make_env_script_list_js,
     make_eval_script_list_js,
 )
+from swebench.harness.test_spec.php import (
+    make_repo_script_list_php,
+    make_env_script_list_php,
+    make_eval_script_list_php,
+)
 from swebench.harness.test_spec.python import (
     make_repo_script_list_py,
     make_env_script_list_py,
@@ -20,6 +25,7 @@ def make_repo_script_list(
     ext = MAP_REPO_TO_EXT[repo]
     func = {
         "js": make_repo_script_list_js,
+        "php": make_repo_script_list_php,
         "py": make_repo_script_list_py,
     }[ext]
     return func(specs, repo, repo_directory, base_commit, env_name)
@@ -33,6 +39,7 @@ def make_env_script_list(instance, specs, env_name) -> list:
     ext = MAP_REPO_TO_EXT[instance["repo"]]
     func = {
         "js": make_env_script_list_js,
+        "php": make_env_script_list_php,
         "py": make_env_script_list_py,
     }[ext]
     return func(instance, specs, env_name)
@@ -46,6 +53,7 @@ def make_eval_script_list(
     ext = MAP_REPO_TO_EXT[instance["repo"]]
     func = {
         "js": make_eval_script_list_js,
+        "php": make_eval_script_list_php,
         "py": make_eval_script_list_py,
     }[ext]
     return func(instance, specs, env_name, repo_directory, base_commit, test_patch)

--- a/swebench/harness/test_spec/php.py
+++ b/swebench/harness/test_spec/php.py
@@ -1,0 +1,15 @@
+from swebench.harness.test_spec.common import make_env_script_list_common, make_eval_script_list_common, make_repo_script_list_common
+
+
+# MARK: Script Creation Functions
+
+def make_repo_script_list_php(specs, repo, repo_directory, base_commit, env_name) -> list:
+    return make_repo_script_list_common(specs, repo, repo_directory, base_commit, env_name)
+
+
+def make_env_script_list_php(instance, specs, env_name) -> list:
+    return make_env_script_list_common(instance, specs, env_name)
+
+
+def make_eval_script_list_php(instance, specs, env_name, repo_directory, base_commit, test_patch) -> list:
+    return make_eval_script_list_common(instance, specs, env_name, repo_directory, base_commit, test_patch)

--- a/swebench/harness/utils.py
+++ b/swebench/harness/utils.py
@@ -288,6 +288,13 @@ def str2bool(v):
         raise ArgumentTypeError("Boolean value expected.")
 
 
+def str_or_none(value: str) -> str | None:
+    """Convert string 'none' to None, otherwise return the string."""
+    if value.lower() == 'none':
+        return None
+    return value
+
+
 def get_repo_file(repo, commit, filepath):
     url = f'https://raw.githubusercontent.com/{repo}/{commit}/{filepath}'
     try:

--- a/swebench/harness/utils.py
+++ b/swebench/harness/utils.py
@@ -60,14 +60,14 @@ def get_predictions_from_file(predictions_path: str, dataset_name: str, split: s
             predictions = [json.loads(line) for line in f]
     else:
         raise ValueError("Predictions path must be .json or .jsonl")
-    
+
     # Validate that each prediction has an instance_id
     for pred in predictions:
         if not isinstance(pred, dict):
             raise ValueError(f"Each prediction must be a dictionary, got {type(pred)}")
         if KEY_INSTANCE_ID not in pred:
             raise ValueError(f"Each prediction must contain '{KEY_INSTANCE_ID}'")
-    
+
     return predictions
 
 
@@ -128,8 +128,11 @@ def load_swebench_dataset(name="princeton-nlp/SWE-bench", split="test", instance
     if instance_ids:
         instance_ids = set(instance_ids)
     # Load from local .json/.jsonl file
-    if name.endswith(".json") or name.endswith(".jsonl"):
+    if name.endswith(".json"):
         dataset = json.loads(Path(name).read_text())
+        dataset_ids = {instance[KEY_INSTANCE_ID] for instance in dataset}
+    elif name.endswith(".jsonl"):
+        dataset = [json.loads(line) for line in Path(name).read_text().splitlines()]
         dataset_ids = {instance[KEY_INSTANCE_ID] for instance in dataset}
     else:
         # Load from Hugging Face Datasets


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to https://github.com/swe-bench/SWE-bench/issues/313

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->
This PR adds support for PHP instances that I've been collecting in https://github.com/kabirgh/SWE-bench-multi.
- Add php dockerfiles, a phpunit test log parser, and a single instance from the https://github.com/PHPOffice/PhpSpreadsheet repository.
- Fixed local jsonl dataset handling (previously could only read json datasets)
- Updated parsing for the `run_evaluation` script so that `--namespace none` sets the namespace as `None` (previously there was no way to do this, so it all docker images were assumed to be remote)

_Testing_
I tested that dockerfile builds gold patch solves the instances with 
```
python -m swebench.harness.run_evaluation \
        --dataset_name "/path/to/php_instances.jsonl" \
        --predictions_path gold \
        --namespace none \
        --run_id php_5 
```

I've attached the run_evaluation folder as [php_eval_log.zip](https://github.com/user-attachments/files/18759791/php_eval_log.zip)

#### Any other comments?

PR is best reviewed per commit.
I'll migrate more instances for PHP in future PRs if this approach looks alright to you.

🧡 Thanks for contributing!
