### PR TITLE
Fix: modify unbound variable `REPO_NAME` to `NEW_REPO_NAME`

### DIFF
--- a/swebench/collect/make_repo/make_repo.sh
+++ b/swebench/collect/make_repo/make_repo.sh
@@ -67,7 +67,7 @@ if [ -d "$NEW_REPO_NAME/.github/workflows" ]; then
     git push origin main;  # Change 'master' to your desired branch
     cd ..;
 else
-    echo "$REPO_NAME/.github/workflows does not exist. No action required."
+    echo "$NEW_REPO_NAME/.github/workflows does not exist. No action required."
 fi
 
 rm -rf "$NEW_REPO_NAME"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
None.

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->

There is an unbound variable `REPO_NAME` in the `make_repo.sh`. If users execute this shell script on repos without workflows, they will encounter an error:
```
make_repo/make_repo.sh: line 70: REPO_NAME: unbound variable
```

#### Any other comments?
None.

🧡 Thanks for contributing!
