### PR TITLE
Fix misleading removed images count

### DIFF
--- a/swebench/harness/docker_utils.py
+++ b/swebench/harness/docker_utils.py
@@ -279,17 +279,15 @@ def clean_images(
             in the current run will be removed.
     """
     images = list_images(client)
-    removed = 0
     print("Cleaning cached images...")
     for image_name in images:
         if should_remove(image_name, cache_level, clean, prior_images):
             try:
                 remove_image(client, image_name, "quiet")
-                removed += 1
             except Exception as e:
                 print(f"Error removing image {image_name}: {e}")
                 continue
-    print(f"Removed {removed} images.")
+    print("Image cleaning completed.")
 
 
 def should_remove(image_name: str, cache_level: str, clean: bool, prior_images: set):


### PR DESCRIPTION
Fixes #282

Remove the count of removed images in the `clean_images` function in `swebench/harness/docker_utils.py`.

* Remove the `removed` variable and its increment in the `clean_images` function.
* Update the print statement to reflect the removal of the count, changing it to "Image cleaning completed."

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SWE-bench/SWE-bench/pull/349?shareId=1d9b4701-eb60-4d9c-a183-f5e0dedb22dd).