### PR TITLE
Clean diff after setup

### DIFF
--- a/swebench/harness/test_spec/python.py
+++ b/swebench/harness/test_spec/python.py
@@ -195,6 +195,19 @@ def make_repo_script_list_py(
 
     if "install" in specs:
         setup_commands.append(specs["install"])
+
+    # If the setup modifies the repository in any way, it can be 
+    # difficult to get a clean diff.  This ensures that `git diff`
+    # will only reflect the changes from the user while retaining the
+    # original state of the repository plus setup commands.
+    clean_diff_commands = [
+        "git config --global user.email setup@swebench.config",
+        "git config --global user.name SWE-bench",
+        "git commit --allow-empty -am SWE-bench",
+    ]
+
+    setup_commands += clean_diff_commands
+
     return setup_commands
 
 


### PR DESCRIPTION
Some of the repo_setup.sh scripts leave the working tree in a dirty state which can make it difficult to generate a patch that applies cleanly.  This change commits any outstanding changges such that any patch generated with `git diff` will cleanly apply to a newly launched container during the evaluation step.

<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
Fixes #352 
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
All testbeds should launch with a clean working tree.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->

#### Any other comments?

🧡 Thanks for contributing!
