### PR TITLE
fix: preserve all issue references with same keyword in PRs

### DIFF
--- a/swebench/collect/utils.py
+++ b/swebench/collect/utils.py
@@ -101,12 +101,12 @@ class Repo:
         text = comments_pat.sub("", text)
         # Look for issue numbers in text via scraping <keyword, number> patterns
         references = issues_pat.findall(text)
-        resolved_issues = list()
+        resolved_issues_set = set()
         if references:
             for word, issue_num in references:
                 if word.lower() in PR_KEYWORDS:
-                    resolved_issues.append(issue_num)
-        return resolved_issues
+                    resolved_issues_set.add(issue_num)
+        return list(resolved_issues_set)
 
     def get_all_loop(
         self,

--- a/swebench/collect/utils.py
+++ b/swebench/collect/utils.py
@@ -100,10 +100,10 @@ class Repo:
         # Remove comments from text
         text = comments_pat.sub("", text)
         # Look for issue numbers in text via scraping <keyword, number> patterns
-        references = dict(issues_pat.findall(text))
+        references = issues_pat.findall(text)
         resolved_issues = list()
         if references:
-            for word, issue_num in references.items():
+            for word, issue_num in references:
                 if word.lower() in PR_KEYWORDS:
                     resolved_issues.append(issue_num)
         return resolved_issues


### PR DESCRIPTION
# Fix Multiple Issue References with Same Keyword in PRs

## Problem

In the current implementation, when a PR contains multiple issue references using the same keyword (e.g., "Fix"), only the last referenced issue is preserved. This occurs because the `extract_resolved_issues` method uses `dict(issues_pat.findall(text))`, which converts regex matches to a dictionary, causing multiple references with the same keyword to be overwritten.

For example, when a PR contains:
Fix #26194
Fix #26230


Only `26230` is recognized as a resolved issue, while `26194` is ignored.

## Solution

1. Modified the `extract_resolved_issues` method in `utils.py` to directly use the list of matches from `issues_pat.findall(text)` instead of converting it to a dictionary, preserving all matches.

2. Added a `log_single_pull` function to `print_pulls.py` and introduced a `--pull_number` parameter to facilitate testing and verification of specific PRs.

## Verification

Before the fix:
python print_pulls.py lowRISC/opentitan output_pr_26371.json --pull_number 26371
2025-03-06 21:49:31,392 - main - INFO - Fetching PR #26371 from lowRISC/opentitan
2025-03-06 21:49:33,746 - main - INFO - PR #26371 saved to output_pr_26371.json
2025-03-06 21:49:33,746 - main - INFO - Resolved issues: ['26230']

After the fix:
python print_pulls.py lowRISC/opentitan output_pr_26371.json --pull_number 26371
2025-03-06 21:48:05,467 - main - INFO - Fetching PR #26371 from lowRISC/opentitan
2025-03-06 21:48:07,775 - main - INFO - PR #26371 saved to output_pr_26371.json
2025-03-06 21:48:07,775 - main - INFO - Resolved issues: ['26194', '26230']

Now all issue references using the same keyword are correctly identified and preserved.