### PR TITLE
catch-all exception for docker pull

### DIFF
--- a/swebench/harness/docker_build.py
+++ b/swebench/harness/docker_build.py
@@ -463,6 +463,10 @@ def build_container(
                 client.images.pull(test_spec.instance_image_key)
             except docker.errors.NotFound as e:
                 raise BuildImageError(test_spec.instance_id, str(e), logger) from e
+            except Exception as e:
+                raise Exception(
+                    f"Error occurred while pulling image {test_spec.base_image_key}: {str(e)}"
+                )
 
     container = None
     try:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->

Previously, the exception was `except docker.errors.NotFound as e:`, so any other type of error was silently failing. This PR adds a catch-all exception for other types of exceptions


#### Any other comments?

🧡 Thanks for contributing!
