### PR TITLE
Fix: the pbar doesn't update immediately when futures fail unless there are subsequent successful futures.

### DIFF
--- a/swebench/harness/utils.py
+++ b/swebench/harness/utils.py
@@ -87,14 +87,14 @@ def run_threadpool(func, payloads, max_workers):
             # Wait for each future to complete
             for future in as_completed(futures):
                 try:
-                    # Update progress bar, check if instance ran successfully
+                    # Check if instance ran successfully
                     future.result()
                     succeeded.append(futures[future])
                 except Exception as e:
                     print(f"{type(e)}: {e}")
                     traceback.print_exc()
                     failed.append(futures[future])
-                    continue
+                # Update progress bar
                 pbar.update(1)
                 pbar.set_description(
                     f"{len(succeeded)} ran successfully, {len(failed)} failed"

--- a/tests/test_harness_utils.py
+++ b/tests/test_harness_utils.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from tqdm import tqdm
+from swebench.harness.utils import run_threadpool
+
+class UtilTests(unittest.TestCase):
+    @patch('swebench.harness.utils.tqdm')
+    def test_pbar_updates_correctly_with_all_failures(self, mock_tqdm):
+        # Create mock progress bar
+        mock_pbar = MagicMock()
+
+        # Configure mock chain
+        mock_tqdm.return_value = mock_pbar
+        mock_pbar.__enter__.return_value = mock_pbar
+        mock_pbar.__exit__.return_value = None
+
+        def failing_func(_):
+            raise ValueError("Test error")
+
+        # Run the function
+        payloads = [(1,), (2,), (3,)]
+        succeeded, failed = run_threadpool(failing_func, payloads, max_workers=2)
+
+        # Verify mock_pbar was used correctly
+        self.assertEqual(3, len(failed))
+        self.assertEqual(3, mock_pbar.update.call_count)
+        self.assertEqual(3, mock_pbar.set_description.call_count)
+        mock_pbar.set_description.assert_called_with(
+            "0 ran successfully, 3 failed"
+        )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
None.

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->
Because of the incorrect `continue` line, pbar doesn't update immediately when futures fail unless there are subsequent successful futures.
