### PR TITLE
Support for datasets without constants files

### DIFF
--- a/swebench/harness/constants/__init__.py
+++ b/swebench/harness/constants/__init__.py
@@ -55,6 +55,7 @@ class TestStatus(Enum):
     SKIPPED = "SKIPPED"
     ERROR = "ERROR"
     XFAIL = "XFAIL"
+    XPASS = "XPASS"
 
 
 class EvalType(Enum):

--- a/swebench/harness/constants/__init__.py
+++ b/swebench/harness/constants/__init__.py
@@ -34,6 +34,7 @@ class SWEbenchInstance(TypedDict):
     FAIL_TO_PASS: str
     PASS_TO_PASS: str
     environment_setup_commit: str
+    docker_image_root: str | None
 
 
 # Constants - Test Types, Statuses, Commands

--- a/swebench/harness/docker_utils.py
+++ b/swebench/harness/docker_utils.py
@@ -299,16 +299,15 @@ def should_remove(image_name: str, cache_level: str, clean: bool, prior_images: 
     existed_before = image_name in prior_images
     if "/" in image_name:
         image_name = image_name.split("/", 1)[-1]
-    if image_name.startswith("swa-bench"):
-        image_name = image_name.replace("swa-bench:","")
+    image_name = image_name.split(".", maxsplit=1)[-1]  # strip the docker root and prefix
 
-    if image_name.startswith("sweb.base") or image_name.startswith("sw.base"):
+    if image_name.startswith("base"):
         if cache_level in {"none"} and (clean or not existed_before):
             return True
-    elif image_name.startswith("sweb.env") or image_name.startswith("sw.env"):
+    elif image_name.startswith("env"):
         if cache_level in {"none", "base"} and (clean or not existed_before):
             return True
-    elif image_name.startswith("sweb.eval") or image_name.startswith("sw.eval"):
+    elif image_name.startswith("eval"):
         if cache_level in {"none", "base", "env"} and (clean or not existed_before):
             return True
     return False

--- a/swebench/harness/docker_utils.py
+++ b/swebench/harness/docker_utils.py
@@ -299,13 +299,16 @@ def should_remove(image_name: str, cache_level: str, clean: bool, prior_images: 
     existed_before = image_name in prior_images
     if "/" in image_name:
         image_name = image_name.split("/", 1)[-1]
-    if image_name.startswith("sweb.base"):
+    if image_name.startswith("swa-bench"):
+        image_name = image_name.replace("swa-bench:","")
+
+    if image_name.startswith("sweb.base") or image_name.startswith("sw.base"):
         if cache_level in {"none"} and (clean or not existed_before):
             return True
-    elif image_name.startswith("sweb.env"):
+    elif image_name.startswith("sweb.env") or image_name.startswith("sw.env"):
         if cache_level in {"none", "base"} and (clean or not existed_before):
             return True
-    elif image_name.startswith("sweb.eval"):
+    elif image_name.startswith("sweb.eval") or image_name.startswith("sw.eval"):
         if cache_level in {"none", "base", "env"} and (clean or not existed_before):
             return True
     return False

--- a/swebench/harness/grading.py
+++ b/swebench/harness/grading.py
@@ -21,11 +21,13 @@ from swebench.harness.constants import (
 )
 from swebench.harness.test_spec.test_spec import TestSpec
 from swebench.harness.log_parsers import MAP_REPO_TO_PARSER
+from swebench.harness.log_parsers.python import  sw_parser
 
 
 # MARK: Utility functions
 def test_passed(case: str, sm: dict[str, str]) -> bool:
-    return case in sm and sm[case] in [TestStatus.PASSED.value, TestStatus.XFAIL.value]
+    # Keeping XFAIL for backward compatibility but should be considered failure
+    return case in sm and sm[case] in [TestStatus.PASSED.value, TestStatus.XFAIL.value, TestStatus.XPASS.value]
 
 
 def test_failed(case: str, sm: dict[str, str]) -> bool:
@@ -46,11 +48,7 @@ def get_logs_eval(test_spec: TestSpec, log_fp: str) -> tuple[dict[str, str], boo
     TODO(john-b-yang): Check this is working properly...
     """
     repo = test_spec.repo
-    version = test_spec.version
-    log_parser = MAP_REPO_TO_PARSER[repo]
-    test_cmd = MAP_REPO_VERSION_TO_SPECS[repo][version]["test_cmd"]
-    if isinstance(test_cmd, list):
-        test_cmd = test_cmd[-1]
+    log_parser = MAP_REPO_TO_PARSER.get(repo, sw_parser)
 
     with open(log_fp) as f:
         content = f.read()

--- a/swebench/harness/test_spec/create_scripts.py
+++ b/swebench/harness/test_spec/create_scripts.py
@@ -19,7 +19,7 @@ def make_repo_script_list(specs, repo, repo_directory, base_commit, env_name) ->
     Create a list of bash commands to set up the repository for testing.
     This is the setup script for the instance image.
     """
-    ext = MAP_REPO_TO_EXT[repo]
+    ext = MAP_REPO_TO_EXT.get(repo, "py")
     func = {
         "py": make_repo_script_list_py,
     }.get(ext, make_repo_script_list_common)
@@ -31,7 +31,7 @@ def make_env_script_list(instance, specs, env_name) -> list:
     Creates the list of commands to set up the environment for testing.
     This is the setup script for the environment image.
     """
-    ext = MAP_REPO_TO_EXT[instance["repo"]]
+    ext = MAP_REPO_TO_EXT.get(instance["repo"], "py")
     func = {
         "py": make_env_script_list_py,
     }.get(ext, make_env_script_list_common)
@@ -44,7 +44,7 @@ def make_eval_script_list(
     """
     Applies the test patch and runs the tests.
     """
-    ext = MAP_REPO_TO_EXT[instance["repo"]]
+    ext = MAP_REPO_TO_EXT.get(instance["repo"], "py")
     common_func = make_eval_script_list_common
     func = {
         "js": make_eval_script_list_js,

--- a/swebench/harness/utils.py
+++ b/swebench/harness/utils.py
@@ -147,6 +147,9 @@ def load_swebench_dataset(
             "lite",
         }:
             name = "SWE-bench/SWE-bench_Lite"
+        elif name.lower() in {'swabench', 'swa-bench', 'swa_bench', 'swa'}:
+            name = "LogicStar/SWA-Bench"
+
         if (Path(name) / split / "dataset_info.json").exists():
             dataset = cast(Dataset, load_from_disk(Path(name) / split))
         else:


### PR DESCRIPTION
This PR adds support for datasets with install and test specs in the dataset itself.

#### Reference Issues/PRs
None

#### What does this implement/fix?
This PR adds support for SWE-Bench-like datasets (such as SWA-Bench) that include test commands and installation specifications in the dataset rather than the constants file. 

This enables using this evaluation harness for community-created datasets without the need to create local versions with modified constant files. 

We test this with SWA-Bench (https://arxiv.org/abs/2503.07701 -- https://huggingface.co/datasets/LogicStar/SWA-Bench).