### PR TITLE
fixes #421 - fix mention of private dockerhub link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ python -m swebench.harness.run_evaluation \
 ```
 > [!NOTE]
 > If using a MacOS M-series or other ARM-based systems, add `--namespace ''` to the above script.
-> By default, the evaluation script pulls images (built for Linux) from [DockerHub](https://hub.docker.com/repositories/swebench).
+> By default, the evaluation script pulls images (built for Linux) from [DockerHub](https://hub.docker.com/u/swebench).
 > Adding `--namespace ''` will cause evaluation images to be built locally instead.
 
 ## 💽 Usage


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #421 

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->
It fixes the mention of a private DockerHub link in the README (README.md) file

#### Any other comments?

<!-- 🧡 Thanks for contributing! -->
