### PR TITLE
Modal evaluation log parsing fix

### DIFF
--- a/swebench/harness/grading.py
+++ b/swebench/harness/grading.py
@@ -73,8 +73,19 @@ def get_logs_eval(test_spec: TestSpec, log_fp: str) -> tuple[dict[str, str], boo
             return {}, False
 
         # Get status map of evaluation results
-        content = content.split(START_TEST_OUTPUT)[1].split(END_TEST_OUTPUT)[0]
-        return log_parser(content, test_spec), True
+        test_content = content.split(START_TEST_OUTPUT)[1].split(END_TEST_OUTPUT)[0]
+        
+        # Try parsing the content between markers first
+        status_map = log_parser(test_content, test_spec)
+        
+        # If no test results found between markers (common in Modal environment),
+        # try parsing the entire log content as fallback
+        if not status_map:
+            # Look for pytest output patterns in the entire log content
+            # This handles cases where pytest output goes to stderr and isn't captured between markers
+            status_map = log_parser(content, test_spec)
+        
+        return status_map, True
 
 
 def get_eval_tests_report(


### PR DESCRIPTION
changed grading.py to correctly parse the logs that are outputted from patch application for each task instance. Correct solutions (even the golden patch) were reported to have failed all unit tests in the reports.json file generated after evaluation is complete.



