### PR TITLE
FIX: "report_dir" did not be used in run_evaluation

### DIFF
--- a/swebench/harness/reporting.py
+++ b/swebench/harness/reporting.py
@@ -19,6 +19,7 @@ def make_run_report(
     full_dataset: list,
     run_id: str,
     client: Optional[docker.DockerClient] = None,
+    report_dir: Optional[str] = None,
 ) -> Path:
     """
     Make a final evaluation and run report of the instances that have been run.
@@ -128,11 +129,17 @@ def make_run_report(
                 "unremoved_images": list(sorted(unremoved_images)),
             }
         )
-    report_file = Path(
+    if report_dir is not None:
+        report_dir = Path(report_dir)
+        report_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        report_dir = Path(".")
+    report_file = report_dir / (
         list(predictions.values())[0][KEY_MODEL].replace("/", "__")
         + f".{run_id}"
         + ".json"
     )
+    print(f"==============Report file: {report_file}==================")
     with open(report_file, "w") as f:
         print(json.dumps(report, indent=4), file=f)
     print(f"Report written to {report_file}")

--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -288,6 +288,7 @@ def run_instances(
         max_workers (int): Maximum number of workers
         run_id (str): Run ID
         timeout (int): Timeout for running tests
+        report_dir (str): Directory to write reports to
     """
     client = docker.from_env()
     test_specs = list(
@@ -469,10 +470,6 @@ def main(
 
     # set open file limit
     assert len(run_id) > 0, "Run ID must be provided"
-    if report_dir is not None:
-        report_dir = Path(report_dir)
-        if not report_dir.exists():
-            report_dir.mkdir(parents=True)
 
     if force_rebuild and namespace is not None:
         raise ValueError("Cannot force rebuild and use a namespace at the same time.")
@@ -524,7 +521,7 @@ def main(
 
     # clean images + make final report
     clean_images(client, existing_images, cache_level, clean)
-    return make_run_report(predictions, full_dataset, run_id, client)
+    return make_run_report(predictions, full_dataset, run_id, client, report_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The ‎`--report_dir` argument in ‎`/swebench/harness/run_evaluation.py` was not used, and the ‎`make_run_report` function in ‎`reporting.py` did not accept a ‎`report_dir` parameter. This has now been fixed in this pr.