### PR TITLE
instance_ids should be space separated, not comma separated

### DIFF
--- a/docs/guides/evaluation.md
+++ b/docs/guides/evaluation.md
@@ -103,7 +103,7 @@ To evaluate only specific instances, use the `--instance_ids` parameter:
 ```bash
 python -m swebench.harness.run_evaluation \
     --predictions_path <path_to_predictions> \
-    --instance_ids httpie-cli__httpie-1088,sympy__sympy-20590 \
+    --instance_ids httpie-cli__httpie-1088 sympy__sympy-20590 \
     --max_workers 2
 ```
 

--- a/docs/reference/harness.md
+++ b/docs/reference/harness.md
@@ -99,7 +99,7 @@ The harness accepts various parameters to configure the evaluation:
 - `--run_id`: Identifier for the evaluation run
 - `--cache_level`: Level of caching for Docker images
 - `--clean`: Whether to clean up resources after evaluation
-- `--instance_ids`: Specific instances to evaluate (comma-separated)
+- `--instance_ids`: Specific instances to evaluate (space-separated)
 - `--open_file_limit`: Open file limit
 - `--force_rebuild`: Force rebuild all images
 - `--log_level`: Logging verbosity


### PR DESCRIPTION
Based on https://github.com/SWE-bench/SWE-bench/blob/c3ace15258615ed30bb2afbc6e1cfbccaef35cda/swebench/harness/run_evaluation.py#L546-L550 `instance_ids` should be space separated (not comma separated).

I've confirmed that running the given example with comma separated values crashes because when comma separated, the `instance_ids` object is a string which looks like this "inst1,inst2,inst3,..." and this breaks `full_dataset = load_swebench_dataset(dataset_name, split, instance_ids)`  in `SWE-bench/swebench/harness/run_evaluation.py` . Running the given example with space separated values works just fine.