### PR TITLE
Update `pytest` workflow

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -44,6 +44,13 @@ jobs:
       - name: Install dev dependencies
         run: |
             uv pip install --python ${Python_ROOT_DIR} pytest pytest-cov
+      - name: Clean Python cache files
+        run: |
+          find . -name "__pycache__" -type d -exec rm -r {} +
+          find . -name "*.pyc" -delete
+      - name: Uninstall any installed swebench package
+        run: |
+          pip uninstall -y swebench || true
       - name: Run pytest
         uses: sjvrijn/pytest-last-failed@v2
         with:


### PR DESCRIPTION
#### Reference Issues/PRs

```
==================================== ERRORS ====================================
___________ ERROR collecting swebench/harness/test_spec/test_spec.py ___________
import file mismatch:
imported module 'swebench.harness.test_spec.test_spec' has this __file__ attribute:
  /opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/swebench/harness/test_spec/test_spec.py
which is not the same as the test file we want to collect:
  /home/runner/work/SWE-bench/SWE-bench/swebench/harness/test_spec/test_spec.py
HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
=========================== short test summary info ============================
ERROR swebench/harness/test_spec/test_spec.py
!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
=============================== 1 error in 3.85s ===============================
```

Sometimes, the `pytest` testing workflow runs into caching related uses such as the above. This PR adds some basic, additional logic to clean up caching before the `pytest` workflow is run.
