### PR TITLE
Clarify Docker cleanup commands in setup guide

### DIFF
--- a/docs/guides/docker_setup.md
+++ b/docs/guides/docker_setup.md
@@ -79,20 +79,14 @@ Useful commands for managing Docker resources:
 # View Docker disk usage
 docker system df
 
-# Remove unused containers
+# Remove all stopped containers
 docker container prune
 
-# Remove unused images
+# Remove dangling images (untagged)
 docker image prune
 
 # Remove all unused Docker objects (containers, images, networks, volumes)
 docker system prune
-
-# Remove all stopped containers
-docker container prune
-
-# Remove all dangling images
-docker image prune
 ```
 
 ## Cache Level Configuration


### PR DESCRIPTION
#### Description

The Docker resource management guide contains duplicate commands that should be cleaned up for clarity.

#### Current Issue

The guide lists these duplicate commands:
- `docker container prune` appears twice (lines with different comments but same functionality)
- `docker image prune` appears twice (lines with different comments but same functionality)

#### What does this implement/fix? 

Remove the duplicate entries and keep the clearer, more accurate comments:
