### PR TITLE
Fix django__django-16877, sphinx-doc__sphinx-8595, sphinx-doc__sphinx-9711

### DIFF
--- a/swebench/harness/test_spec/python.py
+++ b/swebench/harness/test_spec/python.py
@@ -411,7 +411,8 @@ def make_eval_script_list_py(
     HEREDOC_DELIMITER = "EOF_114329324912"
     test_files = get_modified_files(test_patch)
     # Reset test files to the state they should be in before the patch.
-    reset_tests_command = f"git checkout {base_commit} {' '.join(test_files)}"
+    if len(test_files) > 0:
+        reset_tests_command = f"git checkout {base_commit} {' '.join(test_files)}"
     apply_test_patch_command = (
         f"git apply -v - <<'{HEREDOC_DELIMITER}'\n{test_patch}\n{HEREDOC_DELIMITER}"
     )

--- a/swebench/harness/test_spec/python.py
+++ b/swebench/harness/test_spec/python.py
@@ -15,7 +15,7 @@ from swebench.harness.constants import (
     END_TEST_OUTPUT,
     REPO_BASE_COMMIT_BRANCH,
 )
-from swebench.harness.utils import get_modified_files, load_cached_environment_yml
+from swebench.harness.utils import get_patch_files, load_cached_environment_yml
 from functools import cache
 
 HEADERS = {
@@ -409,10 +409,10 @@ def make_eval_script_list_py(
     Applies the test patch and runs the tests.
     """
     HEREDOC_DELIMITER = "EOF_114329324912"
-    test_files = get_modified_files(test_patch)
+    test_files = get_patch_files(test_patch)
     # Reset test files to the state they should be in before the patch.
-    if len(test_files) > 0:
-        reset_tests_command = f"git checkout {base_commit} {' '.join(test_files)}"
+    reset_tests_command = f'for f in {" ".join(test_files)}; do git checkout HEAD -- "$f" || true; done'
+    
     apply_test_patch_command = (
         f"git apply -v - <<'{HEREDOC_DELIMITER}'\n{test_patch}\n{HEREDOC_DELIMITER}"
     )

--- a/swebench/harness/test_spec/utils.py
+++ b/swebench/harness/test_spec/utils.py
@@ -3,7 +3,7 @@ from swebench.harness.constants import (
     MAP_REPO_VERSION_TO_SPECS,
     START_TEST_OUTPUT,
 )
-from swebench.harness.utils import get_modified_files
+from swebench.harness.utils import get_patch_files
 
 
 # MARK: Test Command Creation Functions
@@ -63,12 +63,9 @@ def make_eval_script_list_common(
     Applies the test patch and runs the tests.
     """
     HEREDOC_DELIMITER = "EOF_114329324912"
-    test_files = get_modified_files(test_patch)
+    test_files = get_patch_files(test_patch)
     # Reset test files to the state they should be in before the patch.
-    if test_files:
-        reset_tests_command = f"git checkout {base_commit} {' '.join(test_files)}"
-    else:
-        reset_tests_command = 'echo "No test files to reset"'
+    reset_tests_command = f'for f in {" ".join(test_files)}; do git checkout HEAD -- "$f" || true; done'
 
     build_commands = []
     if "build" in specs:

--- a/swebench/harness/utils.py
+++ b/swebench/harness/utils.py
@@ -331,14 +331,13 @@ def get_repo_file(repo, commit, filepath):
         return None
 
 
-def get_modified_files(patch: str) -> list[str]:
+def get_patch_files(patch: str) -> list[str]:
     """
-    Get the list of modified files in a patch
+    Get the list of new and modified files in a patch
     """
     source_files = []
     for file in PatchSet(patch):
-        if file.source_file != "/dev/null":
-            source_files.append(file.source_file)
+        source_files.append(file.source_file)
     source_files = [x[2:] for x in source_files if x.startswith("a/")]
     return source_files
 


### PR DESCRIPTION
### Problem

There’s been an unfortunate series of events that broke three instances:
- `django__django-16877`
- `sphinx-doc__sphinx-8595`
- `sphinx-doc__sphinx-9711`

What these have in common is that their `test_patch` contains only new files.

In the eval script, all modified test files are reset after applying the patch. However, for these three instances the list of modified test files is empty (since all files are new). The relevant line is:

```python
# swebench/harness/test_spec/python.py:414
reset_tests_command = f"git checkout {base_commit} {' '.join(test_files)}"
```

When `test_files` is empty, this command checks out the entire repo at `base_commit` instead of just the intended files. That resets all committed setup changes.

This issue should have been a problem since [#353](https://github.com/SWE-bench/SWE-bench/pull/353), but it likely went unnoticed until last week, when new images were pushed to Docker Hub.

### Fix

Right now, only modified files are reset. The correct behavior is to reset all files touched in the test_patch (both new and modified). This ensures correctness in cases where the agent patch also creates new test files that must be reset.

To achieve this:
- Replaced `get_modified_files` with `get_patch_files`, which returns both new and modified files.
- This guarantees that the `test_files` list is never empty.
- Since git checkout fails if a file does not exist, we now iterate over the list and soft-fail if a file is missing.