### PR TITLE
Fix timezone bug in Python test spec by using Unix timestamps

### DIFF
--- a/swebench/harness/test_spec/python.py
+++ b/swebench/harness/test_spec/python.py
@@ -278,13 +278,13 @@ def make_repo_script_list_py(
         # Remove the remote and tags so the agent won't see newer commits.
         "git remote remove origin",
         # Remove only tags pointing to commits after target timestamp
-        f"TARGET_TIMESTAMP=$(git show -s --format=%ci {base_commit})",
-        'git tag -l | while read tag; do TAG_COMMIT=$(git rev-list -n 1 "$tag"); TAG_TIME=$(git show -s --format=%ci "$TAG_COMMIT"); if [[ "$TAG_TIME" > "$TARGET_TIMESTAMP" ]]; then git tag -d "$tag"; fi; done',
+        f"TARGET_TS=$(git show -s --format=%ct {base_commit})",
+        'git tag -l | while read tag; do TAG_COMMIT=$(git rev-list -n 1 "$tag"); TAG_TS=$(git show -s --format=%ct "$TAG_COMMIT"); if (( TAG_TS > TARGET_TS )); then git tag -d "$tag"; fi; done',
         "git reflog expire --expire=now --all",
         "git gc --prune=now --aggressive",
         # Verify future logs aren't available
-        "AFTER_TIMESTAMP=$(date -d \"$TARGET_TIMESTAMP + 1 second\" '+%Y-%m-%d %H:%M:%S')",
-        'COMMIT_COUNT=$(git log --oneline --all --since="$AFTER_TIMESTAMP" | wc -l)',
+        "AFTER_TS=$((TARGET_TS + 1))",
+        'COMMIT_COUNT=$(git log --oneline --all --after="$AFTER_TS" | wc -l)',
         '[ "$COMMIT_COUNT" -eq 0 ] || exit 1',
         # Make sure conda is available for later use
         "source /opt/miniconda3/bin/activate",


### PR DESCRIPTION
## Description
This PR fixes a timezone-related bug in the Python test specification that could cause issues when comparing commit timestamps across different timezones.

## Changes
- Replace `%ci` (formatted date with timezone) with `%ct` (Unix timestamp) in git show commands
- Use numeric comparison instead of string comparison for timestamps
- Simplify date arithmetic using Unix epoch time instead of `date -d`
- Change `--since` to `--after` parameter for git log with timestamp

## Impact
This eliminates potential timezone-related issues when comparing commit times during repository setup, ensuring consistent behavior regardless of the system's timezone configuration.

## Testing
The changes maintain the same logical behavior while using more robust timestamp handling.