### PR TITLE
fixing unnecesarry git checkout for new test-files scenario

### DIFF
--- a/swebench/harness/test_spec/python.py
+++ b/swebench/harness/test_spec/python.py
@@ -411,7 +411,10 @@ def make_eval_script_list_py(
     HEREDOC_DELIMITER = "EOF_114329324912"
     test_files = get_modified_files(test_patch)
     # Reset test files to the state they should be in before the patch.
-    reset_tests_command = f"git checkout {base_commit} {' '.join(test_files)}"
+    if len(test_files) > 0:
+        reset_tests_command = f"git checkout {base_commit} {' '.join(test_files)}"
+    else:
+        reset_tests_command = 'echo "No test files to reset"'
     apply_test_patch_command = (
         f"git apply -v - <<'{HEREDOC_DELIMITER}'\n{test_patch}\n{HEREDOC_DELIMITER}"
     )


### PR DESCRIPTION
## Problem
For instances with only new tests, git reset to base_commit is not necessary. This is problematic especially when no files were present in git checkout command and any change is reset. For example, in sphinx 9711, 8595, the tox.ini change of adding "-rA" is reset due to git checkout base_commit

## Fix
Check for non-zero number of modified test files and only then perform their reset in `make_eval_script_list_py` https://github.com/SWE-bench/SWE-bench/blob/main/swebench/harness/test_spec/python.py#L405

Note: Same fix already exists in https://github.com/SWE-bench/SWE-bench/blob/main/swebench/harness/test_spec/utils.py#L68
but will not be referenced by `make_eval_script_list` for "py"
