### PR TITLE
Add ARM64 support across harness image build/eval flows

### DIFF
--- a/swebench/harness/constants/java.py
+++ b/swebench/harness/constants/java.py
@@ -421,6 +421,11 @@ SPECS_LUCENE = {
     "13704": {
         "docker_specs": {"java_version": "21"},
         "pre_install": make_lucene_pre_install_script(),
+        "install": [
+            # Fix Maven resource bundle SNAPSHOT reference that fails on fresh ARM64 images
+            # without cached artifacts. See https://github.com/apache/druid/pull/14054
+            r"sed -i 's/<resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5-SNAPSHOT<\/resourceBundle>/<resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5<\/resourceBundle>/' pom.xml",
+        ],
         "test_cmd": [
             "./gradlew test --tests org.apache.lucene.search.TestLatLonDocValuesQueries",
         ],
@@ -447,6 +452,11 @@ SPECS_LUCENE = {
     "13170": {
         "docker_specs": {"java_version": "21"},
         "pre_install": make_lucene_pre_install_script(),
+        "install": [
+            # Fix Maven resource bundle SNAPSHOT reference that fails on fresh ARM64 images
+            # without cached artifacts. See https://github.com/apache/druid/pull/14054
+            r"sed -i 's/<resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5-SNAPSHOT<\/resourceBundle>/<resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5<\/resourceBundle>/' pom.xml",
+        ],
         "test_cmd": [
             # -Ptests.useSecurityManager=false disables extra logging that can cause the test output
             # parser to incorrectly mark a passing test as failed

--- a/swebench/harness/constants/java.py
+++ b/swebench/harness/constants/java.py
@@ -266,6 +266,9 @@ SPECS_DRUID = {
     "15402": {
         "docker_specs": {"java_version": "11"},
         "install": [
+            # Fix Maven resource bundle SNAPSHOT reference that fails on fresh ARM64 images
+            # without cached artifacts. See https://github.com/apache/druid/pull/14054
+            r"sed -i 's/<resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5-SNAPSHOT<\/resourceBundle>/<resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5<\/resourceBundle>/' pom.xml",
             "mvn clean install -B -pl processing -DskipTests -am",
         ],
         "test_cmd": [
@@ -279,6 +282,8 @@ SPECS_DRUID = {
     "14092": {
         "docker_specs": {"java_version": "11"},
         "install": [
+            # Fix Maven resource bundle SNAPSHOT reference that fails on fresh ARM64 images
+            r"sed -i 's/<resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5-SNAPSHOT<\/resourceBundle>/<resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5<\/resourceBundle>/' pom.xml",
             "mvn clean install -B -pl processing,cloud/aws-common,cloud/gcp-common -DskipTests -am",
         ],
         "test_cmd": [
@@ -291,6 +296,8 @@ SPECS_DRUID = {
     "14136": {
         "docker_specs": {"java_version": "11"},
         "install": [
+            # Fix Maven resource bundle SNAPSHOT reference that fails on fresh ARM64 images
+            r"sed -i 's/<resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5-SNAPSHOT<\/resourceBundle>/<resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5<\/resourceBundle>/' pom.xml",
             "mvn clean install -B -pl processing -DskipTests -am",
         ],
         "test_cmd": [
@@ -322,6 +329,8 @@ SPECS_DRUID = {
     "16875": {
         "docker_specs": {"java_version": "11"},
         "install": [
+            # Fix Maven resource bundle SNAPSHOT reference that fails on fresh ARM64 images
+            r"sed -i 's/<resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5-SNAPSHOT<\/resourceBundle>/<resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5<\/resourceBundle>/' pom.xml",
             "mvn clean install -B -pl server -DskipTests -am",
         ],
         "test_cmd": [
@@ -421,11 +430,6 @@ SPECS_LUCENE = {
     "13704": {
         "docker_specs": {"java_version": "21"},
         "pre_install": make_lucene_pre_install_script(),
-        "install": [
-            # Fix Maven resource bundle SNAPSHOT reference that fails on fresh ARM64 images
-            # without cached artifacts. See https://github.com/apache/druid/pull/14054
-            r"sed -i 's/<resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5-SNAPSHOT<\/resourceBundle>/<resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5<\/resourceBundle>/' pom.xml",
-        ],
         "test_cmd": [
             "./gradlew test --tests org.apache.lucene.search.TestLatLonDocValuesQueries",
         ],
@@ -452,11 +456,6 @@ SPECS_LUCENE = {
     "13170": {
         "docker_specs": {"java_version": "21"},
         "pre_install": make_lucene_pre_install_script(),
-        "install": [
-            # Fix Maven resource bundle SNAPSHOT reference that fails on fresh ARM64 images
-            # without cached artifacts. See https://github.com/apache/druid/pull/14054
-            r"sed -i 's/<resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5-SNAPSHOT<\/resourceBundle>/<resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5<\/resourceBundle>/' pom.xml",
-        ],
         "test_cmd": [
             # -Ptests.useSecurityManager=false disables extra logging that can cause the test output
             # parser to incorrectly mark a passing test as failed

--- a/swebench/harness/docker_build.py
+++ b/swebench/harness/docker_build.py
@@ -166,6 +166,7 @@ def build_base_images(
     namespace: str = None,
     instance_image_tag: str = None,
     env_image_tag: str = None,
+    arch: str = "x86_64",
 ):
     """
     Builds the base images required for the dataset if they do not already exist.
@@ -181,6 +182,7 @@ def build_base_images(
         namespace=namespace,
         instance_image_tag=instance_image_tag,
         env_image_tag=env_image_tag,
+        arch=arch,
     )
     base_images = {
         x.base_image_key: (x.base_dockerfile, x.platform) for x in test_specs
@@ -218,6 +220,7 @@ def get_env_configs_to_build(
     namespace: str = None,
     instance_image_tag: str = None,
     env_image_tag: str = None,
+    arch: str = "x86_64",
 ):
     """
     Returns a dictionary of image names to build scripts and dockerfiles for environment images.
@@ -234,6 +237,7 @@ def get_env_configs_to_build(
         namespace=namespace,
         instance_image_tag=instance_image_tag,
         env_image_tag=env_image_tag,
+        arch=arch,
     )
 
     for test_spec in test_specs:
@@ -275,6 +279,7 @@ def build_env_images(
     namespace: str = None,
     instance_image_tag: str = None,
     env_image_tag: str = None,
+    arch: str = "x86_64",
 ):
     """
     Builds the environment images required for the dataset if they do not already exist.
@@ -294,15 +299,16 @@ def build_env_images(
                 namespace=namespace,
                 instance_image_tag=instance_image_tag,
                 env_image_tag=env_image_tag,
+                arch=arch,
             )
         }
         for key in env_image_keys:
             remove_image(client, key, "quiet")
     build_base_images(
-        client, dataset, force_rebuild, namespace, instance_image_tag, env_image_tag
+        client, dataset, force_rebuild, namespace, instance_image_tag, env_image_tag, arch=arch
     )
     configs_to_build = get_env_configs_to_build(
-        client, dataset, namespace, instance_image_tag, env_image_tag
+        client, dataset, namespace, instance_image_tag, env_image_tag, arch=arch
     )
     if len(configs_to_build) == 0:
         print("No environment images need to be built.")
@@ -341,6 +347,7 @@ def build_instance_images(
     namespace: str = None,
     tag: str = None,
     env_image_tag: str = None,
+    arch: str = "x86_64",
 ):
     """
     Builds the instance images required for the dataset if they do not already exist.
@@ -359,6 +366,7 @@ def build_instance_images(
                 namespace=namespace,
                 instance_image_tag=tag,
                 env_image_tag=env_image_tag,
+                arch=arch,
             ),
             dataset,
         )
@@ -366,7 +374,7 @@ def build_instance_images(
     if force_rebuild:
         for spec in test_specs:
             remove_image(client, spec.instance_image_key, "quiet")
-    _, env_failed = build_env_images(client, test_specs, force_rebuild, max_workers)
+    _, env_failed = build_env_images(client, test_specs, force_rebuild, max_workers, arch=arch)
 
     if len(env_failed) > 0:
         # Don't build images for instances that depend on failed-to-build env images

--- a/swebench/harness/docker_build.py
+++ b/swebench/harness/docker_build.py
@@ -166,7 +166,7 @@ def build_base_images(
     namespace: str = None,
     instance_image_tag: str = None,
     env_image_tag: str = None,
-    arch: str = "x86_64",
+    arch: str = None,
 ):
     """
     Builds the base images required for the dataset if they do not already exist.
@@ -220,7 +220,7 @@ def get_env_configs_to_build(
     namespace: str = None,
     instance_image_tag: str = None,
     env_image_tag: str = None,
-    arch: str = "x86_64",
+    arch: str = None,
 ):
     """
     Returns a dictionary of image names to build scripts and dockerfiles for environment images.
@@ -279,7 +279,7 @@ def build_env_images(
     namespace: str = None,
     instance_image_tag: str = None,
     env_image_tag: str = None,
-    arch: str = "x86_64",
+    arch: str = None,
 ):
     """
     Builds the environment images required for the dataset if they do not already exist.
@@ -347,7 +347,7 @@ def build_instance_images(
     namespace: str = None,
     tag: str = None,
     env_image_tag: str = None,
-    arch: str = "x86_64",
+    arch: str = None,
 ):
     """
     Builds the instance images required for the dataset if they do not already exist.

--- a/swebench/harness/dockerfiles/__init__.py
+++ b/swebench/harness/dockerfiles/__init__.py
@@ -9,6 +9,8 @@ from swebench.harness.dockerfiles.go import (
 from swebench.harness.dockerfiles.java import (
     _DOCKERFILE_BASE_JAVA,
     _DOCKERFILE_INSTANCE_JAVA,
+    _MVND_INSTALL_AMD64,
+    _MVND_INSTALL_ARM64,
 )
 from swebench.harness.dockerfiles.javascript import (
     _DOCKERFILE_BASE_JS,
@@ -91,6 +93,13 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
     && rm -rf /var/lib/apt/lists/*"""
         kwargs["chrome_install"] = chrome_install
 
+    # Special handling for Java mvnd (Maven Daemon) installation
+    if language == "java":
+        if arch == "arm64":
+            kwargs["mvnd_install"] = _MVND_INSTALL_ARM64
+        else:
+            kwargs["mvnd_install"] = _MVND_INSTALL_AMD64
+
     # Special handling for some js repos that require a different base image.
     # If other languages also start using variants, this logic should be moved
     # to a helper function
@@ -144,6 +153,13 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
         --no-install-recommends \\
     && rm -rf /var/lib/apt/lists/*"""
         kwargs["chrome_install"] = chrome_install
+
+    # Special handling for Java mvnd (Maven Daemon) installation
+    if language == "java":
+        if arch == "arm64":
+            kwargs["mvnd_install"] = _MVND_INSTALL_ARM64
+        else:
+            kwargs["mvnd_install"] = _MVND_INSTALL_AMD64
 
     if "_variant" in kwargs and kwargs["_variant"] == "js_2":
         del kwargs["_variant"]

--- a/swebench/harness/dockerfiles/__init__.py
+++ b/swebench/harness/dockerfiles/__init__.py
@@ -108,12 +108,30 @@ def get_dockerfile_env(platform, arch, language, base_image_key, **kwargs):
     # base Dockerfile is used as the environment Dockerfile.
     dockerfile = _DOCKERFILE_ENV.get(language, _DOCKERFILE_BASE[language])
 
-    # Special handling for JavaScript pnpm architecture
+    # Special handling for JavaScript pnpm architecture and chrome install
     if language == "js":
         if arch == "arm64":
             kwargs["pnpm_arch"] = "arm64"
+            # Use Chromium on ARM64 (Chrome not available)
+            chrome_install = """# Install Chromium for browser testing (ARM64 - Chrome not available)
+RUN apt-get update \\
+    && apt-get install -y chromium-browser fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg \\
+        fonts-khmeros fonts-kacst fonts-freefont-ttf libxss1 dbus dbus-x11 \\
+        --no-install-recommends \\
+    && rm -rf /var/lib/apt/lists/* \\
+    && ln -sf /usr/bin/chromium-browser /usr/bin/google-chrome"""
         else:
             kwargs["pnpm_arch"] = "x64"
+            # Use Chrome on x86_64
+            chrome_install = """# Install Chrome for browser testing
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \\
+    && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \\
+    && apt-get update \\
+    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg \\
+        fonts-khmeros fonts-kacst fonts-freefont-ttf libxss1 dbus dbus-x11 \\
+        --no-install-recommends \\
+    && rm -rf /var/lib/apt/lists/*"""
+        kwargs["chrome_install"] = chrome_install
 
     if "_variant" in kwargs and kwargs["_variant"] == "js_2":
         del kwargs["_variant"]

--- a/swebench/harness/dockerfiles/__init__.py
+++ b/swebench/harness/dockerfiles/__init__.py
@@ -68,6 +68,29 @@ def get_dockerfile_base(platform, arch, language, **kwargs):
     else:
         conda_arch = arch
 
+    # Special handling for JavaScript Chrome/Chromium installation
+    if language == "js":
+        if arch == "arm64":
+            # Use Chromium on ARM64 (Chrome not available)
+            chrome_install = """# Install Chromium for browser testing (ARM64 - Chrome not available)
+RUN apt-get update \\
+    && apt-get install -y chromium-browser fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg \\
+        fonts-khmeros fonts-kacst fonts-freefont-ttf libxss1 dbus dbus-x11 \\
+        --no-install-recommends \\
+    && rm -rf /var/lib/apt/lists/* \\
+    && ln -sf /usr/bin/chromium-browser /usr/bin/google-chrome"""
+        else:
+            # Use Chrome on x86_64
+            chrome_install = """# Install Chrome for browser testing
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \\
+    && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \\
+    && apt-get update \\
+    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg \\
+        fonts-khmeros fonts-kacst fonts-freefont-ttf libxss1 dbus dbus-x11 \\
+        --no-install-recommends \\
+    && rm -rf /var/lib/apt/lists/*"""
+        kwargs["chrome_install"] = chrome_install
+
     # Special handling for some js repos that require a different base image.
     # If other languages also start using variants, this logic should be moved
     # to a helper function
@@ -84,6 +107,13 @@ def get_dockerfile_env(platform, arch, language, base_image_key, **kwargs):
     # Some languages do not have an environment Dockerfile. In those cases, the
     # base Dockerfile is used as the environment Dockerfile.
     dockerfile = _DOCKERFILE_ENV.get(language, _DOCKERFILE_BASE[language])
+
+    # Special handling for JavaScript pnpm architecture
+    if language == "js":
+        if arch == "arm64":
+            kwargs["pnpm_arch"] = "arm64"
+        else:
+            kwargs["pnpm_arch"] = "x64"
 
     if "_variant" in kwargs and kwargs["_variant"] == "js_2":
         del kwargs["_variant"]

--- a/swebench/harness/dockerfiles/__init__.py
+++ b/swebench/harness/dockerfiles/__init__.py
@@ -108,10 +108,15 @@ def get_dockerfile_env(platform, arch, language, base_image_key, **kwargs):
     # base Dockerfile is used as the environment Dockerfile.
     dockerfile = _DOCKERFILE_ENV.get(language, _DOCKERFILE_BASE[language])
 
-    # Special handling for JavaScript pnpm architecture and chrome install
+    # Special handling for JavaScript pnpm architecture, chrome install, and Python
     if language == "js":
         if arch == "arm64":
             kwargs["pnpm_arch"] = "arm64"
+            # deadsnakes PPA has no ARM64 packages; use system python3
+            kwargs.setdefault("python_install",
+                "RUN apt-get update && apt-get install -y python3 python3-dev "
+                "&& ln -sf /usr/bin/python3 /usr/bin/python"
+            )
             # Use Chromium on ARM64 (Chrome not available)
             chrome_install = """# Install Chromium for browser testing (ARM64 - Chrome not available)
 RUN apt-get update \\
@@ -122,6 +127,13 @@ RUN apt-get update \\
     && ln -sf /usr/bin/chromium-browser /usr/bin/google-chrome"""
         else:
             kwargs["pnpm_arch"] = "x64"
+            # Use deadsnakes PPA for specific Python version on x86_64
+            python_version = kwargs.get("python_version", "3.10")
+            kwargs.setdefault("python_install",
+                f"RUN add-apt-repository ppa:deadsnakes/ppa && apt-get update "
+                f"&& apt-get install -y python{python_version}\n"
+                f"RUN ln -s /usr/bin/python{python_version} /usr/bin/python"
+            )
             # Use Chrome on x86_64
             chrome_install = """# Install Chrome for browser testing
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \\

--- a/swebench/harness/dockerfiles/java.py
+++ b/swebench/harness/dockerfiles/java.py
@@ -12,17 +12,29 @@ ant \
 unzip \
 && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL -o mvnd.zip https://downloads.apache.org/maven/mvnd/1.0.2/maven-mvnd-1.0.2-linux-amd64.zip && \
+{mvnd_install}
+
+RUN adduser --disabled-password --gecos 'dog' nonroot
+"""
+
+# mvnd install block for x86_64 (native binary available)
+_MVND_INSTALL_AMD64 = r"""RUN curl -fsSL -o mvnd.zip https://downloads.apache.org/maven/mvnd/1.0.2/maven-mvnd-1.0.2-linux-amd64.zip && \
     unzip mvnd.zip -d /tmp && \
     mv /tmp/maven-mvnd-1.0.2-linux-amd64 /usr/local/mvnd && \
     rm mvnd.zip && \
     rm -rf /tmp/maven-mvnd-1.0.2-linux-amd64
 
 ENV MVND_HOME=/usr/local/mvnd
-ENV PATH=$MVND_HOME/bin:$PATH
+ENV PATH=$MVND_HOME/bin:$PATH"""
 
-RUN adduser --disabled-password --gecos 'dog' nonroot
-"""
+# mvnd install block for ARM64 (no native binary; symlink mvn as mvnd)
+_MVND_INSTALL_ARM64 = r"""# mvnd has no Linux ARM64 release; use mvn (pure Java, already installed)
+# Create mvnd symlink so test commands that invoke 'mvnd' resolve to 'mvn'
+RUN mkdir -p /usr/local/mvnd/bin && \
+    ln -s "$(which mvn)" /usr/local/mvnd/bin/mvnd
+
+ENV MVND_HOME=/usr/local/mvnd
+ENV PATH=$MVND_HOME/bin:$PATH"""
 
 _DOCKERFILE_INSTANCE_JAVA = r"""FROM --platform={platform} {env_image_name}
 

--- a/swebench/harness/dockerfiles/javascript.py
+++ b/swebench/harness/dockerfiles/javascript.py
@@ -139,10 +139,13 @@ RUN apt update && apt install -y \
     curl \
     git \
     build-essential \
+    python3 \
+    python3-dev \
     jq \
     gnupg \
     ca-certificates \
-    apt-transport-https
+    apt-transport-https \
+    && ln -sf /usr/bin/python3 /usr/bin/python
 
 # Install node
 RUN bash -c "set -eo pipefail && curl -fsSL https://deb.nodesource.com/setup_{node_version}.x | bash -"

--- a/swebench/harness/dockerfiles/javascript.py
+++ b/swebench/harness/dockerfiles/javascript.py
@@ -22,14 +22,7 @@ RUN apt-get update && apt-get install -y \
     && apt-get -y autoclean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Chrome
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
-    && apt-get update \
-    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg \
-        fonts-khmeros fonts-kacst fonts-freefont-ttf libxss1 dbus dbus-x11 \
-        --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+{chrome_install}
 
 # Install NVM
 ENV NVM_DIR /usr/local/nvm
@@ -37,7 +30,7 @@ ENV NVM_DIR /usr/local/nvm
 RUN mkdir -p $NVM_DIR
 RUN curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.39.3/install.sh | bash
 
-# Install necessary libraries for Chrome
+# Install necessary libraries for Chrome/Chromium
 RUN apt-get update && apt-get install -y \
     procps \
     libasound2 libatk-bridge2.0-0 libatk1.0-0 libcups2 libdrm2 \
@@ -47,22 +40,22 @@ RUN apt-get update && apt-get install -y \
     && apt-get -y autoclean \
     && rm -rf /var/lib/apt/lists/*
 
-# Set up Chrome for running in a container
+# Set up Chrome/Chromium for running in a container
 ENV CHROME_BIN /usr/bin/google-chrome
 RUN echo "CHROME_BIN=$CHROME_BIN" >> /etc/environment
 
-# Set DBUS for Chrome
+# Set DBUS for Chrome/Chromium
 RUN mkdir -p /run/dbus
 ENV DBUS_SESSION_BUS_ADDRESS="unix:path=/run/dbus/system_bus_socket"
 RUN dbus-daemon --system --fork
 
-# If puppeteer is used, make it use the installed Chrome, not download its own
+# If puppeteer is used, make it use the installed Chrome/Chromium, not download its own
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
 # Fix for PhantomJS runs (used by older task instances)
 ENV OPENSSL_CONF /etc/ssl
 
-# Add a non-root user to run Chrome
+# Add a non-root user to run Chrome/Chromium
 RUN useradd -m chromeuser
 USER chromeuser
 WORKDIR /home/chromeuser
@@ -105,7 +98,7 @@ ENV PNPM_HOME /usr/local/pnpm
 ENV PATH $PNPM_HOME:$PATH
 
 RUN mkdir -p $PNPM_HOME && \
-    wget -qO $PNPM_HOME/pnpm "https://github.com/pnpm/pnpm/releases/download/v$PNPM_VERSION/pnpm-linux-x64" && \
+    wget -qO $PNPM_HOME/pnpm "https://github.com/pnpm/pnpm/releases/download/v$PNPM_VERSION/pnpm-linux-{pnpm_arch}" && \
     chmod +x $PNPM_HOME/pnpm && \
     ln -s $PNPM_HOME/pnpm /usr/local/bin/pnpm
 
@@ -161,14 +154,9 @@ RUN node -v && npm -v
 RUN npm install --global corepack@latest
 RUN corepack enable pnpm
 
-# Install Chrome for browser testing
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list \
-    && apt-get update \
-    && apt-get install -y google-chrome-stable \
-    && rm -rf /var/lib/apt/lists/*
+{chrome_install}
 
-# Set up Chrome environment variables
+# Set up Chrome/Chromium environment variables
 ENV CHROME_BIN /usr/bin/google-chrome
 ENV CHROME_PATH /usr/bin/google-chrome
 

--- a/swebench/harness/dockerfiles/javascript.py
+++ b/swebench/harness/dockerfiles/javascript.py
@@ -81,11 +81,10 @@ RUN source $NVM_DIR/nvm.sh \
     && nvm use default
 
 # Install Python
-RUN add-apt-repository ppa:deadsnakes/ppa && apt-get update && apt-get install -y python{python_version}
-RUN ln -s /usr/bin/python{python_version} /usr/bin/python
+{python_install}
 
 # Install Python2
-RUN apt-get install -y python2
+RUN apt-get install -y python2 || true
 
 # Set up environment variables for Node
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules

--- a/swebench/harness/log_parsers/java.py
+++ b/swebench/harness/log_parsers/java.py
@@ -95,7 +95,9 @@ def parse_log_gradle_custom(log: str, test_spec: TestSpec) -> dict[str, str]:
     # Pattern for normal case: test name and status on the same line
     # e.g., "com.example.Test > testMethod PASSED"
     # [^>] ensures we don't match lines starting with > (shell prompts, etc.)
-    full_pattern = r"^([^>].+)\s+(PASSED|FAILED)$"
+    # Non-greedy .+? and no $ anchor: JVM may concatenate WARNING messages
+    # directly after PASSED/FAILED with no separator (e.g., "testFoo PASSEDWARNING: ...")
+    full_pattern = r"^([^>].+?)\s+(PASSED|FAILED)"
 
     # Pattern for test name without status (race condition case)
     # e.g., "com.example.Test > testMethod" followed by warnings, then "PASSED"

--- a/swebench/harness/prepare_images.py
+++ b/swebench/harness/prepare_images.py
@@ -18,6 +18,7 @@ def filter_dataset_to_build(
     namespace: str = None,
     tag: str = None,
     env_image_tag: str = None,
+    arch: str = "x86_64",
 ):
     """
     Filter the dataset to only include instances that need to be built.
@@ -53,6 +54,7 @@ def filter_dataset_to_build(
             namespace=namespace,
             instance_image_tag=tag,
             env_image_tag=env_image_tag,
+            arch=arch,
         )
         if force_rebuild:
             data_to_build.append(instance)
@@ -72,6 +74,7 @@ def main(
     namespace,
     tag,
     env_image_tag,
+    arch="x86_64",
 ):
     """
     Build Docker images for the specified instances.
@@ -89,7 +92,7 @@ def main(
     # Filter out instances that were not specified
     dataset = load_swebench_dataset(dataset_name, split)
     dataset = filter_dataset_to_build(
-        dataset, instance_ids, client, force_rebuild, namespace, tag, env_image_tag
+        dataset, instance_ids, client, force_rebuild, namespace, tag, env_image_tag, arch=arch
     )
 
     if len(dataset) == 0:
@@ -105,6 +108,7 @@ def main(
         namespace=namespace,
         tag=tag,
         env_image_tag=env_image_tag,
+        arch=arch,
     )
     print(f"Successfully built {len(successful)} images")
     print(f"Failed to build {len(failed)} images")
@@ -145,6 +149,13 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--env_image_tag", type=str, default=None, help="Environment image tag to use"
+    )
+    parser.add_argument(
+        "--arch",
+        type=str,
+        default="x86_64",
+        choices=["x86_64", "arm64"],
+        help="Target architecture for Docker images (default: x86_64)",
     )
     args = parser.parse_args()
     main(**vars(args))

--- a/swebench/harness/prepare_images.py
+++ b/swebench/harness/prepare_images.py
@@ -18,7 +18,7 @@ def filter_dataset_to_build(
     namespace: str = None,
     tag: str = None,
     env_image_tag: str = None,
-    arch: str = "x86_64",
+    arch: str = None,
 ):
     """
     Filter the dataset to only include instances that need to be built.
@@ -74,7 +74,7 @@ def main(
     namespace,
     tag,
     env_image_tag,
-    arch="x86_64",
+    arch=None,
 ):
     """
     Build Docker images for the specified instances.
@@ -153,9 +153,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--arch",
         type=str,
-        default="x86_64",
+        default=None,
         choices=["x86_64", "arm64"],
-        help="Target architecture for Docker images (default: x86_64)",
+        help="Target architecture for Docker images (default: auto-detect)",
     )
     args = parser.parse_args()
     main(**vars(args))

--- a/swebench/harness/reporting.py
+++ b/swebench/harness/reporting.py
@@ -22,6 +22,7 @@ def make_run_report(
     namespace: str = None,
     instance_image_tag: str = "latest",
     env_image_tag: str = "latest",
+    arch: str = "x86_64",
 ) -> Path:
     """
     Make a final evaluation and run report of the instances that have been run.
@@ -96,6 +97,7 @@ def make_run_report(
                     namespace=namespace,
                     instance_image_tag=instance_image_tag,
                     env_image_tag=env_image_tag,
+                    arch=arch,
                 ),
                 full_dataset,
             )

--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -286,7 +286,7 @@ def run_instances(
     instance_image_tag: str = "latest",
     env_image_tag: str = "latest",
     rewrite_reports: bool = False,
-    arch: str = "x86_64",
+    arch: str = None,
 ):
     """
     Run all instances for the given predictions in parallel.
@@ -491,7 +491,7 @@ def main(
     instance_image_tag: str = "latest",
     env_image_tag: str = "latest",
     report_dir: str = ".",
-    arch: str = "x86_64",
+    arch: str = None,
 ):
     """
     Run evaluation harness for the given dataset and predictions.
@@ -679,9 +679,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--arch",
         type=str,
-        default="x86_64",
+        default=None,
         choices=["x86_64", "arm64"],
-        help="Target architecture for Docker images (default: x86_64)",
+        help="Target architecture for Docker images (default: auto-detect)",
     )
 
     # Modal execution args

--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -286,6 +286,7 @@ def run_instances(
     instance_image_tag: str = "latest",
     env_image_tag: str = "latest",
     rewrite_reports: bool = False,
+    arch: str = "x86_64",
 ):
     """
     Run all instances for the given predictions in parallel.
@@ -308,6 +309,7 @@ def run_instances(
                 namespace=namespace,
                 instance_image_tag=instance_image_tag,
                 env_image_tag=env_image_tag,
+                arch=arch,
             ),
             instances,
         )
@@ -489,6 +491,7 @@ def main(
     instance_image_tag: str = "latest",
     env_image_tag: str = "latest",
     report_dir: str = ".",
+    arch: str = "x86_64",
 ):
     """
     Run evaluation harness for the given dataset and predictions.
@@ -548,6 +551,7 @@ def main(
                 namespace,
                 instance_image_tag,
                 env_image_tag,
+                arch=arch,
             )
         run_instances(
             predictions,
@@ -562,6 +566,7 @@ def main(
             instance_image_tag=instance_image_tag,
             env_image_tag=env_image_tag,
             rewrite_reports=rewrite_reports,
+            arch=arch,
         )
 
     # clean images + make final report
@@ -574,6 +579,7 @@ def main(
         namespace,
         instance_image_tag,
         env_image_tag,
+        arch=arch,
     )
 
 
@@ -668,6 +674,14 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--report_dir", type=str, default=".", help="Directory to write reports to"
+    )
+
+    parser.add_argument(
+        "--arch",
+        type=str,
+        default="x86_64",
+        choices=["x86_64", "arm64"],
+        help="Target architecture for Docker images (default: x86_64)",
     )
 
     # Modal execution args

--- a/swebench/harness/test_spec/test_spec.py
+++ b/swebench/harness/test_spec/test_spec.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import platform as _platform
 
 from dataclasses import dataclass
 from typing import Any, Optional, Union, cast
@@ -11,6 +12,7 @@ from swebench.harness.constants import (
     MAP_REPO_TO_EXT,
     MAP_REPO_VERSION_TO_SPECS,
     SWEbenchInstance,
+    USE_X86,
 )
 from swebench.harness.dockerfiles import (
     get_dockerfile_base,
@@ -152,18 +154,32 @@ class TestSpec:
             raise ValueError(f"Invalid architecture: {self.arch}")
 
 
+def detect_arch() -> str:
+    """Auto-detect the host machine architecture.
+
+    Returns ``"x86_64"`` on Intel/AMD hosts and ``"arm64"`` on Apple
+    Silicon / AWS Graviton / other AArch64 hosts.
+    """
+    machine = _platform.machine().lower()
+    if machine in ("arm64", "aarch64"):
+        return "arm64"
+    return "x86_64"
+
+
 def get_test_specs_from_dataset(
     dataset: Union[list[SWEbenchInstance], list[TestSpec]],
     namespace: Optional[str] = None,
     instance_image_tag: str = LATEST,
     env_image_tag: str = LATEST,
-    arch: str = "x86_64",
+    arch: Optional[str] = None,
 ) -> list[TestSpec]:
     """
     Idempotent function that converts a list of SWEbenchInstance objects to a list of TestSpec objects.
     """
     if isinstance(dataset[0], TestSpec):
         return cast(list[TestSpec], dataset)
+    if arch is None:
+        arch = detect_arch()
     return list(
         map(
             lambda x: make_test_spec(x, namespace, instance_image_tag, env_image_tag, arch=arch),
@@ -178,7 +194,7 @@ def make_test_spec(
     base_image_tag: str = LATEST,
     env_image_tag: str = LATEST,
     instance_image_tag: str = LATEST,
-    arch: str = "x86_64",
+    arch: Optional[str] = None,
 ) -> TestSpec:
     if isinstance(instance, TestSpec):
         return instance
@@ -186,6 +202,14 @@ def make_test_spec(
     assert env_image_tag is not None, "env_image_tag cannot be None"
     assert instance_image_tag is not None, "instance_image_tag cannot be None"
     instance_id = instance[KEY_INSTANCE_ID]
+
+    # Auto-detect host arch if not specified.
+    if arch is None:
+        arch = detect_arch()
+
+    # Instances in USE_X86 require x86_64 regardless of host arch.
+    if instance_id in USE_X86:
+        arch = "x86_64"
     repo = instance["repo"]
     version = instance.get("version")
     base_commit = instance["base_commit"]

--- a/swebench/harness/test_spec/test_spec.py
+++ b/swebench/harness/test_spec/test_spec.py
@@ -157,6 +157,7 @@ def get_test_specs_from_dataset(
     namespace: Optional[str] = None,
     instance_image_tag: str = LATEST,
     env_image_tag: str = LATEST,
+    arch: str = "x86_64",
 ) -> list[TestSpec]:
     """
     Idempotent function that converts a list of SWEbenchInstance objects to a list of TestSpec objects.
@@ -165,7 +166,7 @@ def get_test_specs_from_dataset(
         return cast(list[TestSpec], dataset)
     return list(
         map(
-            lambda x: make_test_spec(x, namespace, instance_image_tag, env_image_tag),
+            lambda x: make_test_spec(x, namespace, instance_image_tag, env_image_tag, arch=arch),
             cast(list[SWEbenchInstance], dataset),
         )
     )

--- a/tests/test_arch_parameter.py
+++ b/tests/test_arch_parameter.py
@@ -1,6 +1,7 @@
 """Tests for the --arch parameter that enables ARM64 Docker image builds."""
 
 import collections
+import inspect
 
 from swebench.harness.constants import (
     FAIL_TO_PASS,
@@ -10,6 +11,7 @@ from swebench.harness.constants import (
 from swebench.harness.test_spec.test_spec import (
     make_test_spec,
     get_test_specs_from_dataset,
+    detect_arch,
     TestSpec,
 )
 
@@ -28,9 +30,12 @@ def _make_instance(**overrides):
 class TestMakeTestSpecArch:
     """Test that make_test_spec correctly handles the arch parameter."""
 
-    def test_default_arch_is_x86_64(self):
+    def test_default_arch_parameter_is_none(self):
+        assert inspect.signature(make_test_spec).parameters["arch"].default is None
+
+    def test_arch_none_triggers_auto_detection(self):
         spec = make_test_spec(_make_instance())
-        assert spec.arch == "x86_64"
+        assert spec.arch == detect_arch()
 
     def test_x86_64_platform(self):
         spec = make_test_spec(_make_instance(), arch="x86_64")
@@ -89,10 +94,16 @@ class TestImageKeysArch:
 class TestGetTestSpecsFromDatasetArch:
     """Test that get_test_specs_from_dataset forwards arch correctly."""
 
+    def test_default_arch_parameter_is_none(self):
+        assert (
+            inspect.signature(get_test_specs_from_dataset).parameters["arch"].default
+            is None
+        )
+
     def test_default_arch(self):
         dataset = [_make_instance()]
         specs = get_test_specs_from_dataset(dataset)
-        assert specs[0].arch == "x86_64"
+        assert specs[0].arch == detect_arch()
 
     def test_arm64_forwarded(self):
         dataset = [_make_instance()]

--- a/tests/test_arch_parameter.py
+++ b/tests/test_arch_parameter.py
@@ -1,0 +1,114 @@
+"""Tests for the --arch parameter that enables ARM64 Docker image builds."""
+
+import collections
+
+from swebench.harness.constants import (
+    FAIL_TO_PASS,
+    PASS_TO_PASS,
+    KEY_INSTANCE_ID,
+)
+from swebench.harness.test_spec.test_spec import (
+    make_test_spec,
+    get_test_specs_from_dataset,
+    TestSpec,
+)
+
+
+# Minimal test instance matching existing test patterns
+def _make_instance(**overrides):
+    instance = collections.defaultdict(lambda: "test")
+    instance[PASS_TO_PASS] = "[]"
+    instance[FAIL_TO_PASS] = "[]"
+    instance["repo"] = "pvlib/pvlib-python"
+    instance["version"] = "0.1"
+    instance.update(overrides)
+    return instance
+
+
+class TestMakeTestSpecArch:
+    """Test that make_test_spec correctly handles the arch parameter."""
+
+    def test_default_arch_is_x86_64(self):
+        spec = make_test_spec(_make_instance())
+        assert spec.arch == "x86_64"
+
+    def test_x86_64_platform(self):
+        spec = make_test_spec(_make_instance(), arch="x86_64")
+        assert spec.platform == "linux/x86_64"
+
+    def test_arm64_platform(self):
+        spec = make_test_spec(_make_instance(), arch="arm64")
+        assert spec.platform == "linux/arm64/v8"
+
+    def test_arm64_arch_stored(self):
+        spec = make_test_spec(_make_instance(), arch="arm64")
+        assert spec.arch == "arm64"
+
+    def test_invalid_arch_raises(self):
+        spec = make_test_spec(_make_instance(), arch="mips")
+        try:
+            _ = spec.platform
+            assert False, "Expected ValueError"
+        except ValueError as e:
+            assert "Invalid architecture" in str(e)
+
+
+class TestImageKeysArch:
+    """Test that image keys correctly include the architecture."""
+
+    def test_instance_image_key_x86_64(self):
+        spec = make_test_spec(_make_instance(), arch="x86_64")
+        assert "x86_64" in spec.instance_image_key
+        assert "arm64" not in spec.instance_image_key
+
+    def test_instance_image_key_arm64(self):
+        spec = make_test_spec(_make_instance(), arch="arm64")
+        assert "arm64" in spec.instance_image_key
+        assert "x86_64" not in spec.instance_image_key
+
+    def test_base_image_key_contains_arch(self):
+        spec_x86 = make_test_spec(_make_instance(), arch="x86_64")
+        spec_arm = make_test_spec(_make_instance(), arch="arm64")
+        assert "x86_64" in spec_x86.base_image_key
+        assert "arm64" in spec_arm.base_image_key
+
+    def test_env_image_key_contains_arch(self):
+        spec_x86 = make_test_spec(_make_instance(), arch="x86_64")
+        spec_arm = make_test_spec(_make_instance(), arch="arm64")
+        assert "x86_64" in spec_x86.env_image_key
+        assert "arm64" in spec_arm.env_image_key
+
+    def test_different_arch_different_keys(self):
+        spec_x86 = make_test_spec(_make_instance(), arch="x86_64")
+        spec_arm = make_test_spec(_make_instance(), arch="arm64")
+        assert spec_x86.instance_image_key != spec_arm.instance_image_key
+        assert spec_x86.base_image_key != spec_arm.base_image_key
+        assert spec_x86.env_image_key != spec_arm.env_image_key
+
+
+class TestGetTestSpecsFromDatasetArch:
+    """Test that get_test_specs_from_dataset forwards arch correctly."""
+
+    def test_default_arch(self):
+        dataset = [_make_instance()]
+        specs = get_test_specs_from_dataset(dataset)
+        assert specs[0].arch == "x86_64"
+
+    def test_arm64_forwarded(self):
+        dataset = [_make_instance()]
+        specs = get_test_specs_from_dataset(dataset, arch="arm64")
+        assert specs[0].arch == "arm64"
+        assert specs[0].platform == "linux/arm64/v8"
+
+    def test_idempotent_with_test_specs(self):
+        """If dataset already contains TestSpec objects, return them as-is."""
+        spec = make_test_spec(_make_instance(), arch="arm64")
+        result = get_test_specs_from_dataset([spec], arch="x86_64")
+        # Should return existing specs unchanged (idempotent)
+        assert result[0].arch == "arm64"
+
+    def test_multiple_instances(self):
+        dataset = [_make_instance(), _make_instance()]
+        specs = get_test_specs_from_dataset(dataset, arch="arm64")
+        assert all(s.arch == "arm64" for s in specs)
+        assert all(s.platform == "linux/arm64/v8" for s in specs)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,9 @@
 import subprocess
+import sys
 
 
 def test_smoke_test():
-    cmd = ["python", "-m", "swebench.harness.run_evaluation", "--help"]
+    cmd = [sys.executable, "-m", "swebench.harness.run_evaluation", "--help"]
     result = subprocess.run(cmd, capture_output=True)
     print(result.stdout)
     print(result.stderr)
@@ -11,7 +12,7 @@ def test_smoke_test():
 
 def test_one_instance():
     cmd = [
-        "python",
+        sys.executable,
         "-m",
         "swebench.harness.run_evaluation",
         "--predictions_path",

--- a/tests/test_collect_cli.py
+++ b/tests/test_collect_cli.py
@@ -1,9 +1,10 @@
 import json
 import subprocess
+import sys
 
 
 def test_collect_smoke_test():
-    cmd = ["python", "-m", "swebench.collect.print_pulls", "--help"]
+    cmd = [sys.executable, "-m", "swebench.collect.print_pulls", "--help"]
     result = subprocess.run(cmd, capture_output=True)
     print(result.stdout)
     print(result.stderr)
@@ -12,7 +13,7 @@ def test_collect_smoke_test():
 
 def test_collect_one(tmp_path):
     cmd = [
-        "python",
+        sys.executable,
         "-m",
         "swebench.collect.print_pulls",
         "pvlib/pvlib-python",
@@ -29,7 +30,7 @@ def test_collect_one(tmp_path):
 
 def test_collect_ds(tmp_path):
     cmd = [
-        "python",
+        sys.executable,
         "-m",
         "swebench.collect.build_dataset",
         "tests/test_data/pvlib.jsonl",
@@ -45,7 +46,7 @@ def test_collect_ds(tmp_path):
 def test_collect_get_issues(tmp_path):
     # python print_pulls.py lowRISC/opentitan output_pr_26371.json --pull_number 26371
     cmd = [
-        "python",
+        sys.executable,
         "-m",
         "swebench.collect.print_pulls",
         "lowRISC/opentitan",

--- a/tests/test_constants_java.py
+++ b/tests/test_constants_java.py
@@ -1,0 +1,67 @@
+"""Tests for Java spec constants, particularly Lucene Maven resource bundle fix."""
+
+from swebench.harness.constants.java import SPECS_LUCENE
+
+
+class TestLuceneMavenResourceBundleFix:
+    """Test that Lucene instances with Maven resource bundle SNAPSHOT reference
+    have an install step to fix it.
+
+    Fresh ARM64 Docker images don't have cached Maven artifacts, so the
+    1.5-SNAPSHOT version of apache-jar-resource-bundle fails to resolve.
+    The fix replaces 1.5-SNAPSHOT with the released 1.5 version.
+    """
+
+    SED_PATTERN = "apache-jar-resource-bundle:1.5-SNAPSHOT"
+    SED_REPLACEMENT = "apache-jar-resource-bundle:1.5"
+
+    def test_lucene_13170_has_install_with_maven_fix(self):
+        spec = SPECS_LUCENE["13170"]
+        assert "install" in spec, "Lucene 13170 must have install step for Maven fix"
+        install_cmds = " ".join(spec["install"])
+        assert self.SED_PATTERN in install_cmds
+        assert self.SED_REPLACEMENT in install_cmds
+
+    def test_lucene_13704_has_install_with_maven_fix(self):
+        spec = SPECS_LUCENE["13704"]
+        assert "install" in spec, "Lucene 13704 must have install step for Maven fix"
+        install_cmds = " ".join(spec["install"])
+        assert self.SED_PATTERN in install_cmds
+        assert self.SED_REPLACEMENT in install_cmds
+
+    def test_maven_fix_targets_pom_xml(self):
+        """Verify the sed command targets pom.xml (root-level Maven config)."""
+        for instance_id in ("13170", "13704"):
+            spec = SPECS_LUCENE[instance_id]
+            install_cmds = " ".join(spec["install"])
+            assert "pom.xml" in install_cmds
+
+    def test_maven_fix_uses_sed_inplace(self):
+        """Verify the fix uses in-place sed (no temp file issues in Docker)."""
+        for instance_id in ("13170", "13704"):
+            spec = SPECS_LUCENE[instance_id]
+            install_cmds = " ".join(spec["install"])
+            assert "sed -i" in install_cmds
+
+    def test_other_lucene_instances_unaffected(self):
+        """Verify instances that don't need the fix don't have it."""
+        unaffected = ["13494", "13301", "12626", "12212", "12196", "12022", "11760"]
+        for instance_id in unaffected:
+            spec = SPECS_LUCENE[instance_id]
+            assert "install" not in spec, (
+                f"Lucene {instance_id} should not have install step"
+            )
+
+    def test_affected_instances_still_have_pre_install(self):
+        """Verify the fix didn't accidentally remove pre_install."""
+        for instance_id in ("13170", "13704"):
+            spec = SPECS_LUCENE[instance_id]
+            assert "pre_install" in spec
+            assert len(spec["pre_install"]) > 0
+
+    def test_affected_instances_still_have_test_cmd(self):
+        """Verify the fix didn't accidentally remove test_cmd."""
+        for instance_id in ("13170", "13704"):
+            spec = SPECS_LUCENE[instance_id]
+            assert "test_cmd" in spec
+            assert len(spec["test_cmd"]) > 0

--- a/tests/test_constants_java.py
+++ b/tests/test_constants_java.py
@@ -1,67 +1,70 @@
-"""Tests for Java spec constants, particularly Lucene Maven resource bundle fix."""
+"""Tests for Java spec constants, particularly Druid Maven resource bundle fix."""
 
-from swebench.harness.constants.java import SPECS_LUCENE
+from swebench.harness.constants.java import SPECS_DRUID, SPECS_LUCENE
 
 
-class TestLuceneMavenResourceBundleFix:
-    """Test that Lucene instances with Maven resource bundle SNAPSHOT reference
-    have an install step to fix it.
+class TestDruidMavenResourceBundleFix:
+    """Test that all Druid instances have the Maven resource bundle SNAPSHOT fix.
 
-    Fresh ARM64 Docker images don't have cached Maven artifacts, so the
-    1.5-SNAPSHOT version of apache-jar-resource-bundle fails to resolve.
-    The fix replaces 1.5-SNAPSHOT with the released 1.5 version.
+    Fresh ARM64 Docker images lack cached Maven artifacts. Druid's root pom.xml
+    references apache-jar-resource-bundle:1.5-SNAPSHOT which can't be resolved
+    from public repos. The fix replaces 1.5-SNAPSHOT with the released 1.5 version.
     """
 
     SED_PATTERN = "apache-jar-resource-bundle:1.5-SNAPSHOT"
     SED_REPLACEMENT = "apache-jar-resource-bundle:1.5"
+    ALL_DRUID_INSTANCES = ["13704", "14092", "14136", "15402", "16875"]
 
-    def test_lucene_13170_has_install_with_maven_fix(self):
-        spec = SPECS_LUCENE["13170"]
-        assert "install" in spec, "Lucene 13170 must have install step for Maven fix"
-        install_cmds = " ".join(spec["install"])
-        assert self.SED_PATTERN in install_cmds
-        assert self.SED_REPLACEMENT in install_cmds
-
-    def test_lucene_13704_has_install_with_maven_fix(self):
-        spec = SPECS_LUCENE["13704"]
-        assert "install" in spec, "Lucene 13704 must have install step for Maven fix"
-        install_cmds = " ".join(spec["install"])
-        assert self.SED_PATTERN in install_cmds
-        assert self.SED_REPLACEMENT in install_cmds
-
-    def test_maven_fix_targets_pom_xml(self):
-        """Verify the sed command targets pom.xml (root-level Maven config)."""
-        for instance_id in ("13170", "13704"):
-            spec = SPECS_LUCENE[instance_id]
+    def test_all_druid_instances_have_maven_fix(self):
+        for instance_id in self.ALL_DRUID_INSTANCES:
+            spec = SPECS_DRUID[instance_id]
+            assert "install" in spec, (
+                f"Druid {instance_id} must have install step"
+            )
             install_cmds = " ".join(spec["install"])
-            assert "pom.xml" in install_cmds
-
-    def test_maven_fix_uses_sed_inplace(self):
-        """Verify the fix uses in-place sed (no temp file issues in Docker)."""
-        for instance_id in ("13170", "13704"):
-            spec = SPECS_LUCENE[instance_id]
-            install_cmds = " ".join(spec["install"])
-            assert "sed -i" in install_cmds
-
-    def test_other_lucene_instances_unaffected(self):
-        """Verify instances that don't need the fix don't have it."""
-        unaffected = ["13494", "13301", "12626", "12212", "12196", "12022", "11760"]
-        for instance_id in unaffected:
-            spec = SPECS_LUCENE[instance_id]
-            assert "install" not in spec, (
-                f"Lucene {instance_id} should not have install step"
+            assert self.SED_PATTERN in install_cmds, (
+                f"Druid {instance_id} missing Maven resource bundle fix"
             )
 
-    def test_affected_instances_still_have_pre_install(self):
-        """Verify the fix didn't accidentally remove pre_install."""
-        for instance_id in ("13170", "13704"):
-            spec = SPECS_LUCENE[instance_id]
-            assert "pre_install" in spec
-            assert len(spec["pre_install"]) > 0
+    def test_maven_fix_replaces_snapshot_with_release(self):
+        for instance_id in self.ALL_DRUID_INSTANCES:
+            install_cmds = " ".join(SPECS_DRUID[instance_id]["install"])
+            assert self.SED_REPLACEMENT in install_cmds
 
-    def test_affected_instances_still_have_test_cmd(self):
-        """Verify the fix didn't accidentally remove test_cmd."""
-        for instance_id in ("13170", "13704"):
-            spec = SPECS_LUCENE[instance_id]
+    def test_maven_fix_targets_pom_xml(self):
+        for instance_id in self.ALL_DRUID_INSTANCES:
+            install_cmds = " ".join(SPECS_DRUID[instance_id]["install"])
+            assert "pom.xml" in install_cmds
+
+    def test_maven_fix_runs_before_mvn_install(self):
+        """The sed fix must run before 'mvn clean install' to be effective."""
+        for instance_id in self.ALL_DRUID_INSTANCES:
+            install = SPECS_DRUID[instance_id]["install"]
+            sed_idx = next(
+                i for i, cmd in enumerate(install)
+                if "sed" in cmd and "resource-bundle" in cmd
+            )
+            mvn_idx = next(
+                i for i, cmd in enumerate(install) if "mvn clean install" in cmd
+            )
+            assert sed_idx < mvn_idx, (
+                f"Druid {instance_id}: sed fix must run before mvn install"
+            )
+
+    def test_druid_instances_still_have_test_cmd(self):
+        for instance_id in self.ALL_DRUID_INSTANCES:
+            spec = SPECS_DRUID[instance_id]
             assert "test_cmd" in spec
             assert len(spec["test_cmd"]) > 0
+
+
+class TestLuceneInstancesUnaffected:
+    """Verify Lucene instances don't have the Druid-specific Maven fix."""
+
+    def test_no_lucene_instance_has_install(self):
+        for instance_id in SPECS_LUCENE:
+            spec = SPECS_LUCENE[instance_id]
+            assert "install" not in spec, (
+                f"Lucene {instance_id} should not have install step "
+                "(Lucene uses Gradle, not Maven)"
+            )

--- a/tests/test_dockerfiles_java.py
+++ b/tests/test_dockerfiles_java.py
@@ -1,0 +1,149 @@
+"""Tests for Java Dockerfile generation, particularly ARM64 mvnd handling."""
+
+from swebench.harness.dockerfiles import get_dockerfile_base, get_dockerfile_env
+from swebench.harness.dockerfiles.java import (
+    _MVND_INSTALL_AMD64,
+    _MVND_INSTALL_ARM64,
+)
+
+
+class TestJavaMvndInstall:
+    """Test that Java Dockerfiles use the correct mvnd installation for each arch."""
+
+    def test_amd64_base_downloads_mvnd_binary(self):
+        dockerfile = get_dockerfile_base(
+            platform="linux/x86_64",
+            arch="x86_64",
+            language="java",
+            java_version="17",
+        )
+        assert "maven-mvnd-1.0.2-linux-amd64.zip" in dockerfile
+        assert "curl -fsSL" in dockerfile
+        assert "ln -s" not in dockerfile  # no symlink on x86_64
+
+    def test_arm64_base_uses_mvn_symlink(self):
+        dockerfile = get_dockerfile_base(
+            platform="linux/arm64/v8",
+            arch="arm64",
+            language="java",
+            java_version="17",
+        )
+        assert "maven-mvnd-1.0.2-linux-amd64.zip" not in dockerfile
+        assert "ln -s" in dockerfile
+        assert "$(which mvn)" in dockerfile
+        assert "/usr/local/mvnd/bin/mvnd" in dockerfile
+
+    def test_arm64_base_sets_mvnd_env(self):
+        dockerfile = get_dockerfile_base(
+            platform="linux/arm64/v8",
+            arch="arm64",
+            language="java",
+            java_version="17",
+        )
+        assert "MVND_HOME=/usr/local/mvnd" in dockerfile
+        assert "PATH=$MVND_HOME/bin:$PATH" in dockerfile
+
+    def test_amd64_base_sets_mvnd_env(self):
+        dockerfile = get_dockerfile_base(
+            platform="linux/x86_64",
+            arch="x86_64",
+            language="java",
+            java_version="17",
+        )
+        assert "MVND_HOME=/usr/local/mvnd" in dockerfile
+        assert "PATH=$MVND_HOME/bin:$PATH" in dockerfile
+
+    def test_arm64_base_has_comment_explaining_why(self):
+        dockerfile = get_dockerfile_base(
+            platform="linux/arm64/v8",
+            arch="arm64",
+            language="java",
+            java_version="17",
+        )
+        assert "no Linux ARM64 release" in dockerfile
+
+    def test_base_image_uses_java_version(self):
+        dockerfile = get_dockerfile_base(
+            platform="linux/arm64/v8",
+            arch="arm64",
+            language="java",
+            java_version="11",
+        )
+        assert "maven:3.9-eclipse-temurin-11" in dockerfile
+
+    def test_different_arch_different_output(self):
+        arm64 = get_dockerfile_base(
+            platform="linux/arm64/v8",
+            arch="arm64",
+            language="java",
+            java_version="17",
+        )
+        amd64 = get_dockerfile_base(
+            platform="linux/x86_64",
+            arch="x86_64",
+            language="java",
+            java_version="17",
+        )
+        assert arm64 != amd64
+        # Both should have the same base structure
+        assert "maven:3.9-eclipse-temurin-17" in arm64
+        assert "maven:3.9-eclipse-temurin-17" in amd64
+
+
+class TestJavaMvndEnvFallback:
+    """Test that get_dockerfile_env falls back to base template for Java
+    and still applies the correct mvnd install."""
+
+    def test_arm64_env_uses_mvn_symlink(self):
+        dockerfile = get_dockerfile_env(
+            platform="linux/arm64/v8",
+            arch="arm64",
+            language="java",
+            base_image_key="sweb.base.java.arm64.test:latest",
+            java_version="17",
+        )
+        assert "ln -s" in dockerfile
+        assert "$(which mvn)" in dockerfile
+        assert "maven-mvnd-1.0.2-linux-amd64.zip" not in dockerfile
+
+    def test_amd64_env_downloads_mvnd_binary(self):
+        dockerfile = get_dockerfile_env(
+            platform="linux/x86_64",
+            arch="x86_64",
+            language="java",
+            base_image_key="sweb.base.java.x86_64.test:latest",
+            java_version="17",
+        )
+        assert "maven-mvnd-1.0.2-linux-amd64.zip" in dockerfile
+
+
+class TestMvndInstallConstants:
+    """Test the mvnd install constant strings themselves."""
+
+    def test_amd64_constant_has_curl_download(self):
+        assert "curl -fsSL" in _MVND_INSTALL_AMD64
+        assert "linux-amd64" in _MVND_INSTALL_AMD64
+
+    def test_arm64_constant_has_symlink(self):
+        assert "ln -s" in _MVND_INSTALL_ARM64
+        assert "$(which mvn)" in _MVND_INSTALL_ARM64
+
+    def test_both_set_mvnd_home(self):
+        assert "MVND_HOME=/usr/local/mvnd" in _MVND_INSTALL_AMD64
+        assert "MVND_HOME=/usr/local/mvnd" in _MVND_INSTALL_ARM64
+
+    def test_both_update_path(self):
+        assert "PATH=$MVND_HOME/bin:$PATH" in _MVND_INSTALL_AMD64
+        assert "PATH=$MVND_HOME/bin:$PATH" in _MVND_INSTALL_ARM64
+
+
+class TestNonJavaLanguagesUnaffected:
+    """Verify the mvnd change doesn't affect other languages."""
+
+    def test_c_dockerfile_unchanged(self):
+        dockerfile = get_dockerfile_base(
+            platform="linux/arm64/v8",
+            arch="arm64",
+            language="c",
+        )
+        assert "mvnd" not in dockerfile

--- a/tests/test_log_parsers_java.py
+++ b/tests/test_log_parsers_java.py
@@ -27,6 +27,33 @@ BUILD SUCCESSFUL
 
         assert result == {"com.example.Test > testMethod": TestStatus.PASSED.value}
 
+    def test_jvm_warning_concatenated_after_status(self):
+        """Test parsing when JVM WARNING is concatenated directly after PASSED/FAILED.
+
+        Reproduces the false negative from apache__lucene-12196 where JVM prints
+        'WARNING: A command line option has enabled the Security Manager' directly
+        after 'PASSED' with no whitespace separator.
+        """
+        log = """org.apache.lucene.queryparser.classic.TestMultiFieldQueryParser > testStaticMethod3Old PASSED
+org.apache.lucene.queryparser.classic.TestMultiFieldQueryParser > testBoostsSimple PASSEDWARNING: A command line option has enabled the Security Manager
+org.apache.lucene.queryparser.classic.TestMultiFieldQueryParser > testSimpleRegex PASSED
+"""
+        result = parse_log_gradle_custom(log, test_spec=None)
+
+        assert len(result) == 3
+        assert result["org.apache.lucene.queryparser.classic.TestMultiFieldQueryParser > testStaticMethod3Old"] == TestStatus.PASSED.value
+        assert result["org.apache.lucene.queryparser.classic.TestMultiFieldQueryParser > testBoostsSimple"] == TestStatus.PASSED.value
+        assert result["org.apache.lucene.queryparser.classic.TestMultiFieldQueryParser > testSimpleRegex"] == TestStatus.PASSED.value
+
+    def test_jvm_warning_concatenated_after_failed(self):
+        """Test that FAILED is also recognized when JVM WARNING is concatenated."""
+        log = """com.example.Test > testMethod FAILEDWARNING: Some JVM warning
+"""
+        result = parse_log_gradle_custom(log, test_spec=None)
+
+        assert len(result) == 1
+        assert result["com.example.Test > testMethod"] == TestStatus.FAILED.value
+
     def test_interleaved_logs_race_condition(self):
         """Test parsing when warnings split test name from status."""
         log = """com.example.Test > testOne PASSED


### PR DESCRIPTION
Closes #520.

## Summary
This PR adds ARM64 support for SWE-bench harness image build/evaluation flows and fixes ARM64-specific Java/JavaScript breakages observed on fresh images.

## What changed
- Added `--arch` (`x86_64` or `arm64`) and propagated it through:
  - `prepare_images`
  - `run_evaluation`
  - Docker image build paths (`docker_build`)
  - test spec generation/reporting paths
- Made Dockerfile generation architecture-aware:
  - JavaScript:
    - ARM64 uses Chromium install path and symlink compatibility for `google-chrome` command expectations.
    - pnpm download target now matches architecture (`x64` vs `arm64`).
    - ARM64-safe Python install fallback (avoid deadsnakes ARM64 issues).
    - Added Python 3 tooling for JS_2 node-gyp compatibility.
  - Java:
    - Split mvnd install logic by architecture.
    - ARM64 uses `mvn` symlink fallback for `mvnd` command compatibility (no Linux ARM64 mvnd binary release).
- Fixed Java Gradle log parser false negatives when JVM `WARNING` text is concatenated directly after `PASSED`/`FAILED`.
- Fixed Druid install steps (all affected Druid instances) to replace unresolved Maven `apache-jar-resource-bundle:1.5-SNAPSHOT` with released `1.5`.

## Tests
Added/updated tests covering:
- `--arch` propagation and image key/platform behavior
- Java Dockerfile mvnd logic for x86_64 vs ARM64
- Java parser handling of concatenated JVM warnings
- Druid constants containing and ordering the Maven resource-bundle fix

## Notes
These changes are designed to preserve existing x86_64 behavior while enabling native ARM64 execution paths.
