### PR TITLE
Auto-detect host architecture in make_test_spec

### DIFF
--- a/swebench/harness/test_spec/test_spec.py
+++ b/swebench/harness/test_spec/test_spec.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import platform as _platform
 
 from dataclasses import dataclass
 from typing import Any, Optional, Union, cast
@@ -11,6 +12,7 @@ from swebench.harness.constants import (
     MAP_REPO_TO_EXT,
     MAP_REPO_VERSION_TO_SPECS,
     SWEbenchInstance,
+    USE_X86,
 )
 from swebench.harness.dockerfiles import (
     get_dockerfile_base,
@@ -152,6 +154,18 @@ class TestSpec:
             raise ValueError(f"Invalid architecture: {self.arch}")
 
 
+def detect_arch() -> str:
+    """Auto-detect the host machine architecture.
+
+    Returns ``"x86_64"`` on Intel/AMD hosts and ``"arm64"`` on Apple
+    Silicon / AWS Graviton / other AArch64 hosts.
+    """
+    machine = _platform.machine().lower()
+    if machine in ("arm64", "aarch64"):
+        return "arm64"
+    return "x86_64"
+
+
 def get_test_specs_from_dataset(
     dataset: Union[list[SWEbenchInstance], list[TestSpec]],
     namespace: Optional[str] = None,
@@ -177,7 +191,7 @@ def make_test_spec(
     base_image_tag: str = LATEST,
     env_image_tag: str = LATEST,
     instance_image_tag: str = LATEST,
-    arch: str = "x86_64",
+    arch: Optional[str] = None,
 ) -> TestSpec:
     if isinstance(instance, TestSpec):
         return instance
@@ -185,6 +199,15 @@ def make_test_spec(
     assert env_image_tag is not None, "env_image_tag cannot be None"
     assert instance_image_tag is not None, "instance_image_tag cannot be None"
     instance_id = instance[KEY_INSTANCE_ID]
+
+    # Auto-detect host arch if not specified.
+    if arch is None:
+        arch = detect_arch()
+
+    # Instances in USE_X86 require x86_64 regardless of host arch.
+    if instance_id in USE_X86:
+        arch = "x86_64"
+
     repo = instance["repo"]
     version = instance.get("version")
     base_commit = instance["base_commit"]


### PR DESCRIPTION
Fixes #523. Complements #521.

Auto-detects host arch via `platform.machine()` instead of defaulting to `x86_64`. Instances in `USE_X86` are forced to `x86_64` regardless.