### PR TITLE
Fix flaky Java log parsers: race condition handling

### DIFF
--- a/swebench/harness/log_parsers/java.py
+++ b/swebench/harness/log_parsers/java.py
@@ -20,7 +20,6 @@ def parse_log_maven(log: str, test_spec: TestSpec) -> dict[str, str]:
     """
     test_status_map = {}
     pending_tests: list[str] = []
-    unmatched_results: list[str] = []
 
     # Get the test name from the command used to execute the test.
     # Assumes we run evaluation with set -x
@@ -41,26 +40,10 @@ def parse_log_maven(log: str, test_spec: TestSpec) -> dict[str, str]:
                     test_status_map[test_name] = TestStatus.PASSED.value
                 elif status == "FAILURE":
                     test_status_map[test_name] = TestStatus.FAILED.value
-            else:
-                # Track unmatched results for later matching
-                unmatched_results.append(status)
 
-    # Match any remaining pending tests with unmatched results (FIFO order)
-    # This handles cases where BUILD results appear after other output
-    while pending_tests and unmatched_results:
-        test_name = pending_tests.pop(0)
-        status = unmatched_results.pop(0)
-        if status == "SUCCESS":
-            test_status_map[test_name] = TestStatus.PASSED.value
-        elif status == "FAILURE":
-            test_status_map[test_name] = TestStatus.FAILED.value
-
-    # Warn if there are still pending tests without results
-    if pending_tests:
-        print(
-            f"[WARNING] Maven log parser: {len(pending_tests)} test(s) had no BUILD result: "
-            f"{pending_tests}"
-        )
+    # Any pending tests without a BUILD result are marked as failed
+    for test_name in pending_tests:
+        test_status_map[test_name] = TestStatus.FAILED.value
 
     return test_status_map
 
@@ -94,18 +77,17 @@ def parse_log_gradle_custom(log: str, test_spec: TestSpec) -> dict[str, str]:
 
     # Pattern for normal case: test name and status on the same line
     # e.g., "com.example.Test > testMethod PASSED"
-    # [^>] ensures we don't match lines starting with > (shell prompts, etc.)
-    full_pattern = r"^([^>].+)\s+(PASSED|FAILED)"
+    # Requires " > " to avoid matching non-test lines like "BUILD FAILED"
+    full_pattern = r"^(.+\s+>\s+\S+)\s+(PASSED|FAILED)"
 
     # Pattern for test name without status (race condition case)
     # e.g., "com.example.Test > testMethod" followed by warnings, then "PASSED"
-    # Must also start with [^>] for consistency
-    test_name_pattern = r"^([^>]\S*\s+>\s+\S+)$"
+    test_name_pattern = r"^(\S+\s+>\s+\S+)$"
 
     # Pattern for standalone status line
     status_only_pattern = r"^(PASSED|FAILED)$"
 
-    pending_test_name = None
+    pending_tests: list[str] = []
 
     for line in log.split("\n"):
         stripped = line.strip()
@@ -118,31 +100,28 @@ def parse_log_gradle_custom(log: str, test_spec: TestSpec) -> dict[str, str]:
                 test_status_map[test_name] = TestStatus.PASSED.value
             elif status == "FAILED":
                 test_status_map[test_name] = TestStatus.FAILED.value
-            pending_test_name = None
             continue
 
         # Check for test name without status
         test_name_match = re.match(test_name_pattern, stripped)
         if test_name_match:
-            pending_test_name = test_name_match.group(1)
+            pending_tests.append(test_name_match.group(1))
             continue
 
-        # Check for standalone status (applies to pending test name)
-        if pending_test_name:
+        # Check for standalone status (applies to oldest pending test)
+        if pending_tests:
             status_match = re.match(status_only_pattern, stripped)
             if status_match:
                 status = status_match.group(1)
+                test_name = pending_tests.pop(0)
                 if status == "PASSED":
-                    test_status_map[pending_test_name] = TestStatus.PASSED.value
+                    test_status_map[test_name] = TestStatus.PASSED.value
                 elif status == "FAILED":
-                    test_status_map[pending_test_name] = TestStatus.FAILED.value
-                pending_test_name = None
+                    test_status_map[test_name] = TestStatus.FAILED.value
 
-    # Warn if there's a pending test without a result
-    if pending_test_name:
-        print(
-            f"[WARNING] Gradle log parser: test had no status result: {pending_test_name}"
-        )
+    # Any pending tests without a status result are marked as failed
+    for test_name in pending_tests:
+        test_status_map[test_name] = TestStatus.FAILED.value
 
     return test_status_map
 

--- a/swebench/harness/log_parsers/java.py
+++ b/swebench/harness/log_parsers/java.py
@@ -10,13 +10,17 @@ def parse_log_maven(log: str, test_spec: TestSpec) -> dict[str, str]:
     parser to work, each test must be run individually, and then we look for
     BUILD (SUCCESS|FAILURE) in the logs.
 
+    Handles race conditions where multiple test commands appear before their
+    BUILD results due to concurrent output from shell tracing and Maven.
+
     Args:
         log (str): log content
     Returns:
         dict: test case to test status mapping
     """
     test_status_map = {}
-    current_test_name = "---NO TEST NAME FOUND YET---"
+    pending_tests: list[str] = []
+    unmatched_results: list[str] = []
 
     # Get the test name from the command used to execute the test.
     # Assumes we run evaluation with set -x
@@ -26,15 +30,37 @@ def parse_log_maven(log: str, test_spec: TestSpec) -> dict[str, str]:
     for line in log.split("\n"):
         test_name_match = re.match(test_name_pattern, line.strip())
         if test_name_match:
-            current_test_name = test_name_match.groups()[0]
+            pending_tests.append(test_name_match.groups()[0])
 
         result_match = re.match(result_pattern, line.strip())
         if result_match:
             status = result_match.groups()[0]
-            if status == "SUCCESS":
-                test_status_map[current_test_name] = TestStatus.PASSED.value
-            elif status == "FAILURE":
-                test_status_map[current_test_name] = TestStatus.FAILED.value
+            if pending_tests:
+                test_name = pending_tests.pop(0)
+                if status == "SUCCESS":
+                    test_status_map[test_name] = TestStatus.PASSED.value
+                elif status == "FAILURE":
+                    test_status_map[test_name] = TestStatus.FAILED.value
+            else:
+                # Track unmatched results for later matching
+                unmatched_results.append(status)
+
+    # Match any remaining pending tests with unmatched results (FIFO order)
+    # This handles cases where BUILD results appear after other output
+    while pending_tests and unmatched_results:
+        test_name = pending_tests.pop(0)
+        status = unmatched_results.pop(0)
+        if status == "SUCCESS":
+            test_status_map[test_name] = TestStatus.PASSED.value
+        elif status == "FAILURE":
+            test_status_map[test_name] = TestStatus.FAILED.value
+
+    # Warn if there are still pending tests without results
+    if pending_tests:
+        print(
+            f"[WARNING] Maven log parser: {len(pending_tests)} test(s) had no BUILD result: "
+            f"{pending_tests}"
+        )
 
     return test_status_map
 
@@ -60,19 +86,63 @@ def parse_log_gradle_custom(log: str, test_spec: TestSpec) -> dict[str, str]:
     """
     Parser for test logs generated with 'gradle test'. Assumes that the
     pre-install script to update the gradle config has run.
+
+    Handles race conditions where test name and status appear on different lines
+    due to interleaved log output from concurrent processes.
     """
     test_status_map = {}
 
-    pattern = r"^([^>].+)\s+(PASSED|FAILED)$"
+    # Pattern for normal case: test name and status on the same line
+    # e.g., "com.example.Test > testMethod PASSED"
+    # [^>] ensures we don't match lines starting with > (shell prompts, etc.)
+    full_pattern = r"^([^>].+)\s+(PASSED|FAILED)"
+
+    # Pattern for test name without status (race condition case)
+    # e.g., "com.example.Test > testMethod" followed by warnings, then "PASSED"
+    # Must also start with [^>] for consistency
+    test_name_pattern = r"^([^>]\S*\s+>\s+\S+)$"
+
+    # Pattern for standalone status line
+    status_only_pattern = r"^(PASSED|FAILED)$"
+
+    pending_test_name = None
 
     for line in log.split("\n"):
-        match = re.match(pattern, line.strip())
+        stripped = line.strip()
+
+        # Check for full match (test name + status on same line)
+        match = re.match(full_pattern, stripped)
         if match:
             test_name, status = match.groups()
             if status == "PASSED":
                 test_status_map[test_name] = TestStatus.PASSED.value
             elif status == "FAILED":
                 test_status_map[test_name] = TestStatus.FAILED.value
+            pending_test_name = None
+            continue
+
+        # Check for test name without status
+        test_name_match = re.match(test_name_pattern, stripped)
+        if test_name_match:
+            pending_test_name = test_name_match.group(1)
+            continue
+
+        # Check for standalone status (applies to pending test name)
+        if pending_test_name:
+            status_match = re.match(status_only_pattern, stripped)
+            if status_match:
+                status = status_match.group(1)
+                if status == "PASSED":
+                    test_status_map[pending_test_name] = TestStatus.PASSED.value
+                elif status == "FAILED":
+                    test_status_map[pending_test_name] = TestStatus.FAILED.value
+                pending_test_name = None
+
+    # Warn if there's a pending test without a result
+    if pending_test_name:
+        print(
+            f"[WARNING] Gradle log parser: test had no status result: {pending_test_name}"
+        )
 
     return test_status_map
 

--- a/tests/test_log_parsers_java.py
+++ b/tests/test_log_parsers_java.py
@@ -1,0 +1,92 @@
+from swebench.harness.log_parsers.java import parse_log_gradle_custom, parse_log_maven
+from swebench.harness.constants import TestStatus
+
+
+class TestParseLogGradleCustom:
+    """Tests for parse_log_gradle_custom used by Apache Lucene and RxJava."""
+
+    def test_parse_pass_and_fail(self):
+        """Test parsing normal output with passing and failing tests."""
+        log = """com.example.Test > testOne PASSED
+com.example.Test > testTwo FAILED
+"""
+        result = parse_log_gradle_custom(log, test_spec=None)
+
+        assert len(result) == 2
+        assert result["com.example.Test > testOne"] == TestStatus.PASSED.value
+        assert result["com.example.Test > testTwo"] == TestStatus.FAILED.value
+
+    def test_ignores_non_test_lines(self):
+        """Test that task lines and other noise are ignored."""
+        log = """> Task :test
+WARNING: Some warning
+com.example.Test > testMethod PASSED
+BUILD SUCCESSFUL
+"""
+        result = parse_log_gradle_custom(log, test_spec=None)
+
+        assert result == {"com.example.Test > testMethod": TestStatus.PASSED.value}
+
+    def test_interleaved_logs_race_condition(self):
+        """Test parsing when warnings split test name from status."""
+        log = """com.example.Test > testOne PASSED
+com.example.Test > testTwo
+WARNING: interleaved output
+PASSED
+com.example.Test > testThree
+FAILED
+"""
+        result = parse_log_gradle_custom(log, test_spec=None)
+
+        assert len(result) == 3
+        assert result["com.example.Test > testOne"] == TestStatus.PASSED.value
+        assert result["com.example.Test > testTwo"] == TestStatus.PASSED.value
+        assert result["com.example.Test > testThree"] == TestStatus.FAILED.value
+
+
+class TestParseLogMaven:
+    """Tests for parse_log_maven used by Gson, Druid, JavaParser."""
+
+    def test_parse_sequential_output(self):
+        """Test parsing when commands and results are sequential."""
+        log = """+ mvnd test -B -Dtest=com.example.Test#testOne
+[INFO] BUILD SUCCESS
++ mvnd test -B -Dtest=com.example.Test#testTwo
+[INFO] BUILD FAILURE
+"""
+        result = parse_log_maven(log, test_spec=None)
+
+        assert len(result) == 2
+        assert result["com.example.Test#testOne"] == TestStatus.PASSED.value
+        assert result["com.example.Test#testTwo"] == TestStatus.FAILED.value
+
+    def test_interleaved_commands_race_condition(self):
+        """Test parsing when multiple commands appear before their results."""
+        log = """+ mvnd test -B -Dtest=com.example.Test#testOne
++ mvnd test -B -Dtest=com.example.Test#testTwo
+[INFO] BUILD SUCCESS
+[INFO] BUILD SUCCESS
++ mvnd test -B -Dtest=com.example.Test#testThree
+[INFO] BUILD FAILURE
+"""
+        result = parse_log_maven(log, test_spec=None)
+
+        assert len(result) == 3
+        assert result["com.example.Test#testOne"] == TestStatus.PASSED.value
+        assert result["com.example.Test#testTwo"] == TestStatus.PASSED.value
+        assert result["com.example.Test#testThree"] == TestStatus.FAILED.value
+
+    def test_delayed_build_result_after_marker(self):
+        """Test when BUILD SUCCESS appears after end marker due to buffering."""
+        log = """+ mvnd test -B -Dtest=com.example.Test#testOne
+[INFO] BUILD SUCCESS
++ mvnd test -B -Dtest=com.example.Test#testTwo
++ : '>>>>> End Test Output'
++ git checkout somefile.java
+[INFO] BUILD SUCCESS
+"""
+        result = parse_log_maven(log, test_spec=None)
+
+        assert len(result) == 2
+        assert result["com.example.Test#testOne"] == TestStatus.PASSED.value
+        assert result["com.example.Test#testTwo"] == TestStatus.PASSED.value

--- a/tests/test_log_parsers_java.py
+++ b/tests/test_log_parsers_java.py
@@ -43,6 +43,49 @@ FAILED
         assert result["com.example.Test > testTwo"] == TestStatus.PASSED.value
         assert result["com.example.Test > testThree"] == TestStatus.FAILED.value
 
+    def test_trailing_text_after_status(self):
+        """Test that status followed by trailing text (no space) still matches."""
+        log = """com.example.Test > testOne PASSEDWARNING: A command line option has changed
+com.example.Test > testTwo FAILED some extra text
+"""
+        result = parse_log_gradle_custom(log, test_spec=None)
+
+        assert result["com.example.Test > testOne"] == TestStatus.PASSED.value
+        assert result["com.example.Test > testTwo"] == TestStatus.FAILED.value
+
+    def test_multi_pending_interleaving(self):
+        """Test multiple test headers before their standalone status lines."""
+        log = """com.example.Test > testOne
+com.example.Test > testTwo
+PASSED
+FAILED
+"""
+        result = parse_log_gradle_custom(log, test_spec=None)
+
+        assert len(result) == 2
+        assert result["com.example.Test > testOne"] == TestStatus.PASSED.value
+        assert result["com.example.Test > testTwo"] == TestStatus.FAILED.value
+
+    def test_build_failed_not_matched_as_test(self):
+        """Test that BUILD FAILED is not matched as a test result."""
+        log = """com.example.Test > testOne PASSED
+BUILD FAILED
+"""
+        result = parse_log_gradle_custom(log, test_spec=None)
+
+        assert len(result) == 1
+        assert result["com.example.Test > testOne"] == TestStatus.PASSED.value
+
+    def test_pending_without_result_marked_failed(self):
+        """Test that a test header with no status result is marked as failed."""
+        log = """com.example.Test > testOne PASSED
+com.example.Test > testTwo
+"""
+        result = parse_log_gradle_custom(log, test_spec=None)
+
+        assert result["com.example.Test > testOne"] == TestStatus.PASSED.value
+        assert result["com.example.Test > testTwo"] == TestStatus.FAILED.value
+
 
 class TestParseLogMaven:
     """Tests for parse_log_maven used by Gson, Druid, JavaParser."""
@@ -76,17 +119,25 @@ class TestParseLogMaven:
         assert result["com.example.Test#testTwo"] == TestStatus.PASSED.value
         assert result["com.example.Test#testThree"] == TestStatus.FAILED.value
 
-    def test_delayed_build_result_after_marker(self):
-        """Test when BUILD SUCCESS appears after end marker due to buffering."""
+    def test_pending_without_result_marked_failed(self):
+        """Test that a test command with no BUILD result is marked as failed."""
         log = """+ mvnd test -B -Dtest=com.example.Test#testOne
 [INFO] BUILD SUCCESS
 + mvnd test -B -Dtest=com.example.Test#testTwo
-+ : '>>>>> End Test Output'
-+ git checkout somefile.java
-[INFO] BUILD SUCCESS
 """
         result = parse_log_maven(log, test_spec=None)
 
         assert len(result) == 2
         assert result["com.example.Test#testOne"] == TestStatus.PASSED.value
-        assert result["com.example.Test#testTwo"] == TestStatus.PASSED.value
+        assert result["com.example.Test#testTwo"] == TestStatus.FAILED.value
+
+    def test_stray_build_result_ignored(self):
+        """Test that BUILD results before any test command are ignored."""
+        log = """[INFO] BUILD SUCCESS
++ mvnd test -B -Dtest=com.example.Test#testOne
+[INFO] BUILD FAILURE
+"""
+        result = parse_log_maven(log, test_spec=None)
+
+        assert len(result) == 1
+        assert result["com.example.Test#testOne"] == TestStatus.FAILED.value


### PR DESCRIPTION
## Summary
- **Maven parser**: Replace single `current_test_name` with FIFO queue to handle interleaved test commands and BUILD results from concurrent shell tracing output
- **Gradle parser**: Drop `$` anchor from regex so PASSED/FAILED matches when followed by trailing text (e.g. `PASSEDWARNING:`). Add split-line handling for interleaved output
- Add comprehensive test coverage for both parsers

## Details
Follow-up to PR #506 — `set -x` shell tracing can interleave multiple `mvnd test -Dtest=...` commands before their `BUILD SUCCESS/FAILURE` results appear. The old parser used a single variable, so only the last test name got the result.

Gradle issue: test output like `testGraphTerminatesOnGap PASSEDWARNING: A command line option...` didn't match `(PASSED|FAILED)$` regex.

## Test plan
- [x] Gold eval: `apache__lucene-11760` resolved=true (gradle fix)
- [x] No-patch eval: `apache__lucene-11760` resolved=false
- [x] All RxJava gradle instances unaffected
- [x] New unit tests pass: `pytest tests/test_log_parsers_java.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)