### PR TITLE
fix: Handle Issues Linked with Full URL

### DIFF
--- a/swebench/collect/utils.py
+++ b/swebench/collect/utils.py
@@ -84,8 +84,21 @@ class Repo:
         Return:
             resolved_issues (list): list of issue numbers referenced by PR
         """
+
+        # get repo's issues url to support parsing issues linked with the full url
+        # eg: #1 and https://github.com/git/git/issues/1
+        issue_marker_prefix = r"\#"
+
+        repo_clone_url = pull.get("base", {}).get("repo", {}).get("clone_url")
+        if repo_clone_url and isinstance(repo_clone_url, str):
+            # strip trailing .git
+            repo_base_url = repo_clone_url[:-4]
+            # eg: https://github.com/git/git/issues/
+            repo_issues_url = f"{repo_base_url}/issues/"
+            issue_marker_prefix += "|" + repo_issues_url
+
         # Define 1. issue number regex pattern 2. comment regex pattern 3. keywords
-        issues_pat = re.compile(r"(\w+)\s+\#(\d+)")
+        issues_pat = re.compile(rf"(\w+)\s+(?:{issue_marker_prefix})(\d+)")
         comments_pat = re.compile(r"(?s)<!--.*?-->")
 
         # Construct text to search over for issue numbers from PR body and commit messages

--- a/swebench/collect/utils.py
+++ b/swebench/collect/utils.py
@@ -31,6 +31,19 @@ PR_KEYWORDS = {
 }
 
 
+def build_issues_pattern(clone_url: str | None = None) -> re.Pattern:
+    """Match "<keyword> #123", and full issue URLs for this repo when known.
+
+    e.g. both "fixes #123" and "fixes https://github.com/owner/repo/issues/123".
+    The URL is escaped so its dots cannot act as regex wildcards.
+    """
+    markers = [r"\#"]
+    if clone_url:
+        repo_url = clone_url[: -len(".git")] if clone_url.endswith(".git") else clone_url
+        markers.append(re.escape(f"{repo_url}/issues/"))
+    return re.compile(rf"(\w+)\s+(?:{'|'.join(markers)})(\d+)")
+
+
 class Repo:
     def __init__(self, owner: str, name: str, token: Optional[str] = None):
         """
@@ -85,20 +98,8 @@ class Repo:
             resolved_issues (list): list of issue numbers referenced by PR
         """
 
-        # get repo's issues url to support parsing issues linked with the full url
-        # eg: #1 and https://github.com/git/git/issues/1
-        issue_marker_prefix = r"\#"
-
-        repo_clone_url = pull.get("base", {}).get("repo", {}).get("clone_url")
-        if repo_clone_url and isinstance(repo_clone_url, str):
-            # strip trailing .git
-            repo_base_url = repo_clone_url[:-4]
-            # eg: https://github.com/git/git/issues/
-            repo_issues_url = f"{repo_base_url}/issues/"
-            issue_marker_prefix += "|" + repo_issues_url
-
-        # Define 1. issue number regex pattern 2. comment regex pattern 3. keywords
-        issues_pat = re.compile(rf"(\w+)\s+(?:{issue_marker_prefix})(\d+)")
+        clone_url = ((pull.get("base") or {}).get("repo") or {}).get("clone_url")
+        issues_pat = build_issues_pattern(clone_url)
         comments_pat = re.compile(r"(?s)<!--.*?-->")
 
         # Construct text to search over for issue numbers from PR body and commit messages

--- a/tests/test_collect_issue_refs.py
+++ b/tests/test_collect_issue_refs.py
@@ -1,0 +1,45 @@
+"""Issue references may be written as "#123" or as a full URL (#540)."""
+
+from swebench.collect.utils import build_issues_pattern
+
+CLONE = "https://github.com/owner/repo.git"
+
+
+def _refs(text, clone_url=CLONE):
+    return build_issues_pattern(clone_url).findall(text)
+
+
+def test_hash_form_still_matches():
+    assert _refs("fixes #123") == [("fixes", "123")]
+
+
+def test_full_url_form_matches():
+    assert _refs("fixes https://github.com/owner/repo/issues/123") == [
+        ("fixes", "123")
+    ]
+
+
+def test_both_forms_in_one_body():
+    text = "closes #7 and fixes https://github.com/owner/repo/issues/8"
+    assert _refs(text) == [("closes", "7"), ("fixes", "8")]
+
+
+def test_without_clone_url_only_hash_form():
+    assert _refs("fixes #5", clone_url=None) == [("fixes", "5")]
+    assert _refs("fixes https://github.com/owner/repo/issues/5", clone_url=None) == []
+
+
+def test_url_dots_are_escaped_not_wildcards():
+    """A lookalike host must not match: the escaped dots are literal."""
+    assert _refs("fixes https://githubXcom/owner/repo/issues/9") == []
+
+
+def test_clone_url_without_git_suffix():
+    assert _refs(
+        "fixes https://github.com/owner/repo/issues/4",
+        clone_url="https://github.com/owner/repo",
+    ) == [("fixes", "4")]
+
+
+def test_other_repo_url_is_not_matched():
+    assert _refs("fixes https://github.com/other/proj/issues/1") == []

--- a/uv.lock
+++ b/uv.lock
@@ -669,7 +669,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/21/8464d133752951c154feafb3b65c297e7d80f301183d220bec4c830f1441/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:120fcc53d57903df529c3486962c56528cba5b7d6c57c99537320ed9922c8b86", size = 6073403, upload-time = "2026-05-29T23:11:36.22Z" },
@@ -704,43 +704,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-runtime", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cufft", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
     { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-cupti", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-curand", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvtx", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -835,7 +835,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -844,24 +844,11 @@ wheels = [
 
 [[package]]
 name = "fastcore"
-version = "2.2.10"
+version = "1.14.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/3b/777a17b28561b8bb51726b7d21ae5a32a195b48c148e2acaecad52558715/fastcore-2.2.10.tar.gz", hash = "sha256:20bf780a326f09a2ab872eb2b660ee8616226a898b1b40ea767a389d09529f9c", size = 142021, upload-time = "2026-08-10T06:40:05.451Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/82/6dd84e0498a51f08bb788d8f996bedc39e1c0536261c11e635ffaa2e56ee/fastcore-1.14.5.tar.gz", hash = "sha256:d6f1b4220913642964da6236047fe1e9474ecaeaf38737e144b296c31eb53a3a", size = 102968, upload-time = "2026-07-08T07:16:04.806Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/15/d01a92df7ec458f50b1805866245a0f6d368583387e6bd4905acfb04ced8/fastcore-2.2.10-py3-none-any.whl", hash = "sha256:76d66e731e73b7df68b0f857df2f496eb4fe5f20b4ac7dceb90ec39e5ff1d5bf", size = 148546, upload-time = "2026-08-10T06:40:03.636Z" },
-]
-
-[[package]]
-name = "fastspec"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "fastcore" },
-    { name = "httpx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/e4/9b6bff6090dbb2b27f9db715d3d19794db5776e6a47b3391b017d6c53c21/fastspec-0.2.0.tar.gz", hash = "sha256:3ed3be326f2ee2044fb3c6fbe8091c31ca11681a282d7906196b568e4275aac8", size = 33545, upload-time = "2026-08-09T07:02:21.128Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/fc/8a85ddc8c3510c748250cc7c76ec37656ba020a66c4509fb62b1d8976634/fastspec-0.2.0-py3-none-any.whl", hash = "sha256:82fbae8c2bc06b7487d6c529e7f84e0a3e57f5c2465579cb61b1fa6c0d1fe4ce", size = 31623, upload-time = "2026-08-09T07:02:19.907Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/c3/e2869af29faf757baeb0197fadc635b2e88fe103a8b1ab04722e74dbf07f/fastcore-1.14.5-py3-none-any.whl", hash = "sha256:4b870ee8dc7882b6c280e008ae4d0a355dc2ab4ae1c729a5301413c7f020cc11", size = 108052, upload-time = "2026-07-08T07:16:03.169Z" },
 ]
 
 [[package]]
@@ -1020,16 +1007,14 @@ http = [
 
 [[package]]
 name = "ghapi"
-version = "2.1.1"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastcore" },
-    { name = "fastspec" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/72/f341a5f678f9d84c17fb5e44d1cfec1445c7f989cc4cda6be07350d795b6/ghapi-2.1.1.tar.gz", hash = "sha256:60f309a1a60dfff5e003e3874edd3044e5b029215df07600ba896180ed59e90d", size = 362999, upload-time = "2026-08-10T01:03:44.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/4e/0bd5da23ba419b9da74a1626a328d0ed25afbc359dab17f083463399630a/ghapi-1.1.1.tar.gz", hash = "sha256:0c48132672b2013c0578af1943b748c9269a34c665e47ef2d59cbeab526d0847", size = 81855, upload-time = "2026-07-11T21:44:41.158Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/61/c6d55e7d38f90bd4a33c3f40824e18fef0a1102bc3a9064b16f348c91679/ghapi-2.1.1-py3-none-any.whl", hash = "sha256:41847a25694804a1706a1149c5de767ee95d8c05fa72eaca6ce88165b8663ee0", size = 364025, upload-time = "2026-08-10T01:03:42.225Z" },
+    { url = "https://files.pythonhosted.org/packages/62/3c/68b6f41bba031356ac2c84c6d5c0eb1086d988723f05201b37c54160c2ce/ghapi-1.1.1-py3-none-any.whl", hash = "sha256:459f174304bc92d12f44298f3a8b42c99211e2676a7bc4011f5bd42e5d145b72", size = 80651, upload-time = "2026-07-11T21:44:39.637Z" },
 ]
 
 [[package]]
@@ -2103,7 +2088,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2142,7 +2127,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2154,7 +2139,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2184,9 +2169,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2198,7 +2183,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3413,6 +3398,7 @@ dependencies = [
     { name = "rich" },
     { name = "tenacity" },
     { name = "tqdm" },
+    { name = "typer" },
     { name = "unidiff" },
 ]
 
@@ -3464,7 +3450,7 @@ requires-dist = [
     { name = "datasets" },
     { name = "docker" },
     { name = "flash-attn", marker = "extra == 'inference'", specifier = ">=2.0.0" },
-    { name = "ghapi" },
+    { name = "ghapi", specifier = "<2" },
     { name = "gitpython" },
     { name = "jedi", marker = "extra == 'datasets'" },
     { name = "jedi", marker = "extra == 'inference'" },
@@ -3499,6 +3485,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'datasets'" },
     { name = "transformers", marker = "extra == 'inference'" },
     { name = "triton", marker = "extra == 'inference'" },
+    { name = "typer" },
     { name = "unidiff" },
 ]
 provides-extras = ["datasets", "inference", "test", "docs"]


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Issues can be linked with the full url instead of the `#<number>` shorthand.

For example, in the repo `https://github.com/git/git`
`fixes #1` is the same as
`fixes https://github.com/git/git/issues/1`

[`print_pulls.py`](https://github.com/SWE-bench/SWE-bench/blob/fa79f3af3e0f212d4d14b1c858c77fcaae5308ce/swebench/collect/print_pulls.py) is unable to extract `resolved_issues` for PRs bodies that link issues like this.
This PR extends the regex used to extract issue numbers from the PR body.