### PR TITLE
Build Modal images from harness Dockerfiles for multilingual evaluation

### DIFF
--- a/swebench/harness/modal_eval/run_evaluation_modal.py
+++ b/swebench/harness/modal_eval/run_evaluation_modal.py
@@ -7,6 +7,8 @@ import json
 import modal
 import modal.container_process
 import modal.io_streams
+import shlex
+import tempfile
 import tenacity
 import time
 import traceback
@@ -35,6 +37,88 @@ from swebench.harness.constants import (
 )
 from swebench.harness.grading import get_eval_report
 from swebench.harness.test_spec.test_spec import make_test_spec, TestSpec
+
+
+def _split_dockerfile_from_lines(dockerfile: str) -> tuple[str, list[str]]:
+    lines = dockerfile.strip().splitlines()
+    for idx, line in enumerate(lines):
+        if line.strip().startswith("FROM "):
+            return line.strip(), [line.rstrip() for line in lines[idx + 1 :]]
+    raise ValueError("Dockerfile is missing a FROM instruction")
+
+
+def _extract_from_image_ref(from_instruction: str) -> str:
+    tokens = shlex.split(from_instruction)
+    if len(tokens) < 2 or tokens[0].upper() != "FROM":
+        raise ValueError(f"Invalid FROM instruction: {from_instruction}")
+
+    idx = 1
+    while idx < len(tokens) and tokens[idx].startswith("--"):
+        idx += 1
+    if idx >= len(tokens):
+        raise ValueError(f"Missing image reference in FROM instruction: {from_instruction}")
+
+    return tokens[idx]
+
+
+def _get_modal_sandbox_lifecycle_commands() -> list[str]:
+    # Sandboxes are created without an explicit startup command. Override any
+    # inherited image entrypoint/CMD so long-lived base images like Maven do not
+    # exit immediately or run unrelated startup behavior.
+    return [
+        "ENTRYPOINT []",
+        'CMD ["/bin/sh", "-lc", "while true; do sleep 3600; done"]',
+    ]
+
+
+def _build_modal_image_definition(test_spec: TestSpec) -> tuple[str, list[str]]:
+    # Modal's registry image path only supports single-stage builds. Start from
+    # the public base image, then replay the rendered Docker instructions from
+    # the existing harness Dockerfiles in order.
+    base_from, base_lines = _split_dockerfile_from_lines(test_spec.base_dockerfile)
+    base_image_ref = _extract_from_image_ref(base_from)
+
+    dockerfile_commands = []
+    dockerfile_commands.extend(line for line in base_lines if line.strip())
+
+    if test_spec.env_dockerfile != test_spec.base_dockerfile:
+        _, env_lines = _split_dockerfile_from_lines(test_spec.env_dockerfile)
+        dockerfile_commands.extend(line for line in env_lines if line.strip())
+
+    _, instance_lines = _split_dockerfile_from_lines(test_spec.instance_dockerfile)
+    dockerfile_commands.extend(line for line in instance_lines if line.strip())
+    dockerfile_commands.extend(_get_modal_sandbox_lifecycle_commands())
+
+    return base_image_ref, dockerfile_commands
+
+
+def _get_modal_add_python_version(test_spec: TestSpec) -> str | None:
+    if test_spec.language in {"java", "go", "rs", "rb", "php"}:
+        return "3.11"
+    if (
+        test_spec.language == "js"
+        and test_spec.docker_specs.get("_variant") == "js_2"
+    ):
+        return "3.11"
+    return None
+
+
+def _build_eval_run_command(test_spec: TestSpec, eval_file: str) -> str:
+    run_command = "cd /testbed"
+    # pylint hack
+    if "pylint" in test_spec.instance_id:
+        run_command += " && PYTHONPATH="
+    if test_spec.language == "py":
+        run_command += " && python3 -c 'import sys; sys.setrecursionlimit(10000)'"
+    run_command += f" && /bin/bash {eval_file}"
+    return run_command
+
+
+def _add_sandbox_entrypoint(image: modal.Image) -> modal.Image:
+    return image.add_local_file(
+        LOCAL_SANDBOX_ENTRYPOINT_PATH,
+        REMOTE_SANDBOX_ENTRYPOINT_PATH,
+    )
 
 
 @dataclass
@@ -77,10 +161,7 @@ class ModalSandboxRuntime:
             timeout = 60 * 30
 
         return modal.Sandbox.create(
-            image=self.image.add_local_file(
-                REMOTE_SANDBOX_ENTRYPOINT_PATH,
-                REMOTE_SANDBOX_ENTRYPOINT_PATH,
-            ),
+            image=_add_sandbox_entrypoint(self.image),
             timeout=timeout,
             cpu=4,
         )
@@ -159,59 +240,35 @@ class ModalSandboxRuntime:
     @staticmethod
     def get_instance_image(test_spec: TestSpec) -> modal.Image:
         env_script = test_spec.setup_env_script
-        # add trusted host flag for Modal's PyPI mirror
-        env_script = env_script.replace(
-            "conda activate testbed && python -m pip install -r $HOME/requirements.txt",
-            "conda activate testbed && python -m pip install --trusted-host pypi-mirror.modal.local -r $HOME/requirements.txt",
-        )
+        if test_spec.language == "py":
+            # add trusted host flag for Modal's PyPI mirror
+            env_script = env_script.replace(
+                "conda activate testbed && python -m pip install -r $HOME/requirements.txt",
+                "conda activate testbed && python -m pip install --trusted-host pypi-mirror.modal.local -r $HOME/requirements.txt",
+            )
         repo_script = test_spec.install_repo_script
 
-        remote_env_script_path = "/root/setup_env.sh"
-        remote_repo_script_path = "/root/setup_repo.sh"
+        build_dir = Path(tempfile.mkdtemp(prefix="swebench-modal-image-"))
+        env_script_path = build_dir / "setup_env.sh"
+        repo_script_path = build_dir / "setup_repo.sh"
 
-        Path(remote_env_script_path).write_text(env_script)
-        Path(remote_repo_script_path).write_text(repo_script)
+        env_script_path.write_text(env_script, encoding="utf-8")
+        repo_script_path.write_text(repo_script, encoding="utf-8")
 
-        # Modal automatically caches images
-        # https://modal.com/docs/guide/custom-container#image-caching-and-rebuilds
-        return (
-            modal.Image.from_registry("ubuntu:22.04", add_python="3.11")
-            .run_commands("apt update")
-            .env({"DEBIAN_FRONTEND": "noninteractive", "TZ": "Etc/UTC"})
-            .apt_install(
-                "wget",
-                "git",
-                "build-essential",
-                "libffi-dev",
-                "libtiff-dev",
-                "jq",
-                "curl",
-                "locales",
-                "locales-all",
-                "tzdata",
+        base_image_ref, dockerfile_commands = _build_modal_image_definition(test_spec)
+
+        image_kwargs = {}
+        add_python = _get_modal_add_python_version(test_spec)
+        if add_python is not None:
+            image_kwargs["add_python"] = add_python
+
+        image = modal.Image.from_registry(base_image_ref, **image_kwargs)
+        if dockerfile_commands:
+            image = image.dockerfile_commands(
+                *dockerfile_commands,
+                context_dir=build_dir,
             )
-            .run_commands(
-                "wget 'https://repo.anaconda.com/miniconda/Miniconda3-py311_23.11.0-2-Linux-x86_64.sh' -O miniconda.sh",
-                "bash miniconda.sh -b -p /opt/miniconda3",
-                "echo 'export PATH=/opt/miniconda3/bin:$PATH' >> ~/.bashrc",
-                "/opt/miniconda3/bin/conda init --all",
-                "/opt/miniconda3/bin/conda config --append channels conda-forge",
-                "adduser --disabled-password --gecos 'dog' nonroot",
-            )
-            .add_local_file(
-                Path(remote_env_script_path), remote_env_script_path, copy=True
-            )
-            .add_local_file(
-                Path(remote_repo_script_path), remote_repo_script_path, copy=True
-            )
-            .run_commands(
-                f"chmod +x {remote_env_script_path}",
-                f"/bin/bash -c 'source ~/.bashrc && {remote_env_script_path}'",
-                "echo 'source /opt/miniconda3/etc/profile.d/conda.sh && conda activate testbed' >> /root/.bashrc",
-                f"/bin/bash {remote_repo_script_path}",
-            )
-            .workdir("/testbed/")
-        )
+        return image
 
 
 def get_log_dir(pred: dict, run_id: str, instance_id: str) -> Path:
@@ -222,10 +279,7 @@ def get_log_dir(pred: dict, run_id: str, instance_id: str) -> Path:
 
 
 @app.function(
-    image=swebench_image.add_local_file(
-        LOCAL_SANDBOX_ENTRYPOINT_PATH,
-        REMOTE_SANDBOX_ENTRYPOINT_PATH,
-    ),
+    image=_add_sandbox_entrypoint(swebench_image),
     timeout=120
     * 60,  # Much larger than default timeout to account for image build time
     include_source=True,
@@ -306,14 +360,7 @@ def run_instance_modal(
 
         start_time = time.time()
 
-        run_command = "cd /testbed"
-        # pylint hack
-        if "pylint" in test_spec.instance_id:
-            run_command += " && PYTHONPATH="
-        # increase recursion limit for testing
-        run_command += " && python3 -c 'import sys; sys.setrecursionlimit(10000)'"
-        # run eval script
-        run_command += " && /bin/bash /root/eval.sh"
+        run_command = _build_eval_run_command(test_spec, eval_file)
         test_output, returncode = runner.exec(run_command)
 
         total_runtime = time.time() - start_time

--- a/tests/test_modal_eval_image_builder.py
+++ b/tests/test_modal_eval_image_builder.py
@@ -1,0 +1,350 @@
+import importlib.util
+import shutil
+import sys
+import types
+import unittest
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "swebench"
+    / "harness"
+    / "modal_eval"
+    / "run_evaluation_modal.py"
+)
+
+
+class FakeImage:
+    last_from_registry = None
+    last_dockerfile_commands = None
+    last_add_local_file = None
+
+    @classmethod
+    def reset(cls):
+        cls.last_from_registry = None
+        cls.last_dockerfile_commands = None
+        cls.last_add_local_file = None
+
+    @staticmethod
+    def debian_slim():
+        return FakeImage()
+
+    @staticmethod
+    def from_registry(tag, **kwargs):
+        FakeImage.last_from_registry = (tag, kwargs)
+        return FakeImage()
+
+    def pip_install(self, *_args):
+        return self
+
+    def dockerfile_commands(self, *commands, **kwargs):
+        FakeImage.last_dockerfile_commands = (commands, kwargs)
+        return self
+
+    def add_local_file(self, local_path, remote_path, **kwargs):
+        FakeImage.last_add_local_file = (Path(local_path), remote_path, kwargs)
+        return self
+
+
+class FakeApp:
+    def __init__(self, _name):
+        pass
+
+    def function(self, **_kwargs):
+        def decorator(fn):
+            return fn
+
+        return decorator
+
+
+class FakeLogger:
+    log_file = Path("run_instance.log")
+
+    def info(self, *_args, **_kwargs):
+        pass
+
+    def error(self, *_args, **_kwargs):
+        pass
+
+
+@dataclass
+class FakeTestSpec:
+    instance_id: str
+    language: str
+    base_dockerfile: str
+    env_dockerfile: str
+    instance_dockerfile: str
+    setup_env_script: str = "#!/bin/bash\n"
+    install_repo_script: str = "#!/bin/bash\n"
+    docker_specs: dict = field(default_factory=dict)
+
+
+def _make_package(name: str) -> types.ModuleType:
+    module = types.ModuleType(name)
+    module.__path__ = []
+    return module
+
+
+def load_modal_module():
+    fake_modal = types.ModuleType("modal")
+    fake_modal.App = FakeApp
+    fake_modal.Image = FakeImage
+    fake_modal.Sandbox = types.SimpleNamespace(create=lambda **_kwargs: None)
+    fake_modal.exception = types.SimpleNamespace(
+        SandboxTimeoutError=type("SandboxTimeoutError", (Exception,), {})
+    )
+    fake_modal.enable_output = lambda: types.SimpleNamespace(
+        __enter__=lambda self: None,
+        __exit__=lambda self, exc_type, exc_val, exc_tb: False,
+    )
+
+    fake_modal_container_process = types.ModuleType("modal.container_process")
+    fake_modal_container_process.ContainerProcess = object
+    fake_modal_io_streams = types.ModuleType("modal.io_streams")
+    fake_modal_io_streams.StreamReader = object
+
+    fake_tenacity = types.ModuleType("tenacity")
+    fake_tenacity.retry = lambda *args, **kwargs: (lambda fn: fn)
+    fake_tenacity.stop_after_attempt = lambda attempts: attempts
+    fake_tenacity.wait_exponential = lambda **kwargs: kwargs
+
+    fake_docker_build = types.ModuleType("swebench.harness.docker_build")
+    fake_docker_build.setup_logger = lambda *args, **kwargs: FakeLogger()
+
+    fake_reporting = types.ModuleType("swebench.harness.reporting")
+    fake_reporting.make_run_report = lambda *args, **kwargs: None
+
+    fake_utils = types.ModuleType("swebench.harness.utils")
+
+    class EvaluationError(Exception):
+        pass
+
+    fake_utils.EvaluationError = EvaluationError
+
+    fake_constants = types.ModuleType("swebench.harness.constants")
+    fake_constants.APPLY_PATCH_FAIL = "patch fail"
+    fake_constants.APPLY_PATCH_PASS = "patch pass"
+    fake_constants.RUN_EVALUATION_LOG_DIR = Path("logs/run_evaluation")
+
+    fake_grading = types.ModuleType("swebench.harness.grading")
+    fake_grading.get_eval_report = lambda *args, **kwargs: {}
+
+    fake_test_spec = types.ModuleType("swebench.harness.test_spec.test_spec")
+    fake_test_spec.make_test_spec = lambda instance: instance
+    fake_test_spec.TestSpec = FakeTestSpec
+
+    saved_modules = sys.modules.copy()
+    try:
+        sys.modules["modal"] = fake_modal
+        sys.modules["modal.container_process"] = fake_modal_container_process
+        sys.modules["modal.io_streams"] = fake_modal_io_streams
+        sys.modules["tenacity"] = fake_tenacity
+        sys.modules["swebench"] = _make_package("swebench")
+        sys.modules["swebench.harness"] = _make_package("swebench.harness")
+        sys.modules["swebench.harness.test_spec"] = _make_package(
+            "swebench.harness.test_spec"
+        )
+        sys.modules["swebench.harness.docker_build"] = fake_docker_build
+        sys.modules["swebench.harness.reporting"] = fake_reporting
+        sys.modules["swebench.harness.utils"] = fake_utils
+        sys.modules["swebench.harness.constants"] = fake_constants
+        sys.modules["swebench.harness.grading"] = fake_grading
+        sys.modules["swebench.harness.test_spec.test_spec"] = fake_test_spec
+
+        spec = importlib.util.spec_from_file_location(
+            "run_evaluation_modal_under_test", MODULE_PATH
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.modules.clear()
+        sys.modules.update(saved_modules)
+
+
+class ModalImageBuilderTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = load_modal_module()
+
+    def tearDown(self):
+        FakeImage.reset()
+
+    def test_build_modal_image_definition_uses_env_dockerfile(self):
+        spec = FakeTestSpec(
+            instance_id="django__django-1",
+            language="py",
+            base_dockerfile="\nFROM python-base\nRUN base\n",
+            env_dockerfile="\nFROM env-base\nCOPY ./setup_env.sh /root/\nRUN env\n",
+            instance_dockerfile="\nFROM instance-base\nCOPY ./setup_repo.sh /root/\nRUN repo\n",
+        )
+
+        base_image_ref, dockerfile_commands = self.module._build_modal_image_definition(
+            spec
+        )
+
+        self.assertEqual(base_image_ref, "python-base")
+        self.assertEqual(
+            dockerfile_commands,
+            [
+                "RUN base",
+                "COPY ./setup_env.sh /root/",
+                "RUN env",
+                "COPY ./setup_repo.sh /root/",
+                "RUN repo",
+                "ENTRYPOINT []",
+                'CMD ["/bin/sh", "-lc", "while true; do sleep 3600; done"]',
+            ],
+        )
+
+    def test_build_modal_image_definition_skips_duplicate_env_stage(self):
+        spec = FakeTestSpec(
+            instance_id="google__gson-2061",
+            language="java",
+            base_dockerfile="\nFROM java-base\nRUN base\n",
+            env_dockerfile="\nFROM java-base\nRUN base\n",
+            instance_dockerfile="\nFROM instance-base\nRUN repo\n",
+        )
+
+        base_image_ref, dockerfile_commands = self.module._build_modal_image_definition(
+            spec
+        )
+
+        self.assertEqual(base_image_ref, "java-base")
+        self.assertEqual(len(dockerfile_commands), 4)
+        self.assertEqual(dockerfile_commands[0], "RUN base")
+        self.assertIn("RUN repo", dockerfile_commands[1])
+        self.assertEqual(dockerfile_commands[-2], "ENTRYPOINT []")
+        self.assertEqual(
+            dockerfile_commands[-1],
+            'CMD ["/bin/sh", "-lc", "while true; do sleep 3600; done"]',
+        )
+
+    def test_get_modal_sandbox_lifecycle_commands_override_entrypoint_and_cmd(self):
+        self.assertEqual(
+            self.module._get_modal_sandbox_lifecycle_commands(),
+            [
+                "ENTRYPOINT []",
+                'CMD ["/bin/sh", "-lc", "while true; do sleep 3600; done"]',
+            ],
+        )
+
+    def test_get_instance_image_patches_python_env_script_for_modal(self):
+        spec = FakeTestSpec(
+            instance_id="sympy__sympy-1",
+            language="py",
+            base_dockerfile="\nFROM python-base\nRUN base\n",
+            env_dockerfile="\nFROM env-base\nCOPY ./setup_env.sh /root/\nRUN env\n",
+            instance_dockerfile="\nFROM instance-base\nCOPY ./setup_repo.sh /root/\nRUN repo\n",
+            setup_env_script=(
+                "#!/bin/bash\n"
+                "conda activate testbed && python -m pip install -r $HOME/requirements.txt\n"
+            ),
+        )
+
+        self.module.ModalSandboxRuntime.get_instance_image(spec)
+        tag, kwargs = FakeImage.last_from_registry
+        commands, dockerfile_kwargs = FakeImage.last_dockerfile_commands
+        build_dir = Path(dockerfile_kwargs["context_dir"])
+        self.addCleanup(shutil.rmtree, build_dir, ignore_errors=True)
+
+        self.assertEqual(tag, "python-base")
+        self.assertNotIn("add_python", kwargs)
+        self.assertIn("COPY ./setup_env.sh /root/", commands)
+        self.assertIn(
+            "--trusted-host pypi-mirror.modal.local",
+            (build_dir / "setup_env.sh").read_text(encoding="utf-8"),
+        )
+
+    def test_get_instance_image_adds_python_when_base_image_needs_it(self):
+        spec = FakeTestSpec(
+            instance_id="google__gson-2061",
+            language="java",
+            base_dockerfile="\nFROM java-base\nRUN base\n",
+            env_dockerfile="\nFROM java-base\nRUN base\n",
+            instance_dockerfile="\nFROM instance-base\nRUN repo\n",
+        )
+
+        self.module.ModalSandboxRuntime.get_instance_image(spec)
+        _, kwargs = FakeImage.last_from_registry
+        _, dockerfile_kwargs = FakeImage.last_dockerfile_commands
+        build_dir = Path(dockerfile_kwargs["context_dir"])
+        self.addCleanup(shutil.rmtree, build_dir, ignore_errors=True)
+
+        self.assertEqual(kwargs["add_python"], "3.11")
+
+    def test_get_instance_image_skips_add_python_for_classic_js_images(self):
+        spec = FakeTestSpec(
+            instance_id="markedjs__marked-1",
+            language="js",
+            base_dockerfile="\nFROM js-base\nRUN base\n",
+            env_dockerfile="\nFROM js-env\nCOPY ./setup_env.sh /root/\nRUN env\n",
+            instance_dockerfile="\nFROM instance-base\nRUN repo\n",
+            docker_specs={"node_version": "20"},
+        )
+
+        self.module.ModalSandboxRuntime.get_instance_image(spec)
+        _, kwargs = FakeImage.last_from_registry
+        _, dockerfile_kwargs = FakeImage.last_dockerfile_commands
+        build_dir = Path(dockerfile_kwargs["context_dir"])
+        self.addCleanup(shutil.rmtree, build_dir, ignore_errors=True)
+
+        self.assertNotIn("add_python", kwargs)
+
+    def test_get_instance_image_adds_python_for_js_2_variant(self):
+        spec = FakeTestSpec(
+            instance_id="babel__babel-14532",
+            language="js",
+            base_dockerfile="\nFROM js2-base\nRUN base\n",
+            env_dockerfile="\nFROM js2-base\nRUN base\n",
+            instance_dockerfile="\nFROM instance-base\nRUN repo\n",
+            docker_specs={"node_version": "20", "_variant": "js_2"},
+        )
+
+        self.module.ModalSandboxRuntime.get_instance_image(spec)
+        _, kwargs = FakeImage.last_from_registry
+        _, dockerfile_kwargs = FakeImage.last_dockerfile_commands
+        build_dir = Path(dockerfile_kwargs["context_dir"])
+        self.addCleanup(shutil.rmtree, build_dir, ignore_errors=True)
+
+        self.assertEqual(kwargs["add_python"], "3.11")
+
+    def test_add_sandbox_entrypoint_uses_local_entrypoint_file(self):
+        self.module._add_sandbox_entrypoint(FakeImage())
+
+        local_path, remote_path, _ = FakeImage.last_add_local_file
+
+        self.assertEqual(local_path, self.module.LOCAL_SANDBOX_ENTRYPOINT_PATH)
+        self.assertEqual(remote_path, self.module.REMOTE_SANDBOX_ENTRYPOINT_PATH)
+
+    def test_build_eval_run_command_only_sets_recursion_limit_for_python(self):
+        py_spec = FakeTestSpec(
+            instance_id="django__django-1",
+            language="py",
+            base_dockerfile="",
+            env_dockerfile="",
+            instance_dockerfile="",
+        )
+        java_spec = FakeTestSpec(
+            instance_id="google__gson-2061",
+            language="java",
+            base_dockerfile="",
+            env_dockerfile="",
+            instance_dockerfile="",
+        )
+
+        py_command = self.module._build_eval_run_command(py_spec, "/root/eval.sh")
+        java_command = self.module._build_eval_run_command(java_spec, "/root/eval.sh")
+
+        self.assertIn("sys.setrecursionlimit(10000)", py_command)
+        self.assertNotIn("sys.setrecursionlimit(10000)", java_command)
+        self.assertTrue(java_command.endswith("&& /bin/bash /root/eval.sh"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### Reference Issues/PRs
See also #510

#### What does this implement/fix? Explain your changes.
The Modal evaluation path currently hardcodes a Python-specific Ubuntu/Conda base image in `run_evaluation_modal.py`, ignoring `test_spec.language` entirely. This works fine for Python instances but breaks non-Python ones, since the language-specific toolchains defined in the harness Dockerfiles are never applied.

This PR wires the Modal image build to use the same rendered Dockerfiles that the Docker harness already relies on, without restructuring the runner itself:

- Derive the base image and build steps from `test_spec.base_dockerfile`, `test_spec.env_dockerfile`, and `test_spec.instance_dockerfile`
- Replay those Dockerfile commands through Modal's image builder instead of starting from a hardcoded Python image
- Only add `add_python="3.11"` when the Modal runtime itself needs a Python interpreter
- Only inject the recursion-limit tweak for Python instances
- Override any inherited `ENTRYPOINT`/`CMD` with a keepalive command so base images that define their own startup don't terminate the Modal sandbox prematurely
- Fix the mount path for the local sandbox entrypoint

Files changed:
- `swebench/harness/modal_eval/run_evaluation_modal.py`
- `tests/test_modal_eval_image_builder.py`

Validation:
- `uv run python -m unittest discover -s tests -p 'test_modal_eval_image_builder.py'`
- `uv run python -m py_compile swebench/harness/modal_eval/run_evaluation_modal.py tests/test_modal_eval_image_builder.py`
- Live Modal gold canaries passed for `django__django-10914` (Python), `google__gson-2061` (Java), `gin-gonic__gin-1805` (Go), `burntsushi__ripgrep-2209` (Rust), `fmtlib__fmt-1683` (C), `php-cs-fixer__php-cs-fixer-7523` (PHP), and `axios__axios-4731` (JS)

#### Any other comments?
This is intentionally narrower than #510. It fixes the image-construction path in place rather than rewriting the runner.

It does not implement `run_args` / `cap_add` parity with Docker, so some multilingual instances, especially JS/browser-heavy repos, may still need further work.
