### PR TITLE
Fix Modal eval marker ordering for non-django repos (#447)

### DIFF
--- a/swebench/harness/modal_eval/run_evaluation_modal.py
+++ b/swebench/harness/modal_eval/run_evaluation_modal.py
@@ -17,6 +17,7 @@ from swebench.harness.docker_build import setup_logger
 from swebench.harness.reporting import make_run_report
 from swebench.harness.utils import EvaluationError
 from typing import cast
+from swebench.harness.modal_eval.utils import prepare_modal_eval_script
 
 SANDBOX_ENTRYPOINT = "run_evaluation_modal_entrypoint"
 LOCAL_SANDBOX_ENTRYPOINT_PATH = (
@@ -299,9 +300,7 @@ def run_instance_modal(
         logger.info(f"Git diff before:\n{git_diff_output_before}")
 
         eval_file = "/root/eval.sh"
-        eval_script = test_spec.eval_script
-        # django hack
-        eval_script = eval_script.replace("locale-gen", "locale-gen en_US.UTF-8")
+        eval_script = prepare_modal_eval_script(test_spec.eval_script)
         runner.write_file(eval_file, eval_script)
 
         start_time = time.time()

--- a/swebench/harness/modal_eval/utils.py
+++ b/swebench/harness/modal_eval/utils.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from swebench.harness.test_spec.test_spec import EVAL_SCRIPT_STRICT_MODE_HEADER
+
 
 def validate_modal_credentials():
     """
@@ -12,3 +14,14 @@ def validate_modal_credentials():
             "~/.modal.toml not found - it looks like you haven't configured credentials for Modal.\n"
             "Run 'modal token new' in your terminal to configure credentials."
         )
+
+
+def prepare_modal_eval_script(eval_script: str) -> str:
+    """Apply Modal eval-script fixes: django locale + xtrace->stdout for marker ordering. See #447."""
+    eval_script = eval_script.replace("locale-gen", "locale-gen en_US.UTF-8")
+
+    target = f"{EVAL_SCRIPT_STRICT_MODE_HEADER}\n"
+    replacement = f"BASH_XTRACEFD=1\n{target}"
+    if replacement in eval_script:
+        return eval_script
+    return eval_script.replace(target, replacement, 1)

--- a/swebench/harness/test_spec/test_spec.py
+++ b/swebench/harness/test_spec/test_spec.py
@@ -24,6 +24,9 @@ from swebench.harness.test_spec.create_scripts import (
 )
 
 
+EVAL_SCRIPT_STRICT_MODE_HEADER = "set -uxo pipefail"  # Modal injects BASH_XTRACEFD=1 above this; see #447.
+
+
 @dataclass
 class TestSpec:
     """
@@ -56,7 +59,9 @@ class TestSpec:
     @property
     def eval_script(self):
         return (
-            "\n".join(["#!/bin/bash", "set -uxo pipefail"] + self.eval_script_list)
+            "\n".join(
+                ["#!/bin/bash", EVAL_SCRIPT_STRICT_MODE_HEADER] + self.eval_script_list
+            )
             + "\n"
         )
         # Don't exit early because we need to revert tests at the end

--- a/tests/test_modal_eval.py
+++ b/tests/test_modal_eval.py
@@ -1,0 +1,72 @@
+from swebench.harness.constants import TestStatus as _TestStatus
+from swebench.harness.grading import get_logs_eval
+from swebench.harness.modal_eval.utils import prepare_modal_eval_script
+from swebench.harness.test_spec.test_spec import (
+    EVAL_SCRIPT_STRICT_MODE_HEADER,
+    TestSpec as _TestSpec,
+)
+
+
+def make_test_spec(repo="pvlib/pvlib-python", version="0.1"):
+    return _TestSpec(
+        instance_id="test-instance",
+        repo=repo,
+        version=version,
+        repo_script_list=[],
+        eval_script_list=[],
+        env_script_list=[],
+        arch="x86_64",
+        FAIL_TO_PASS=[],
+        PASS_TO_PASS=[],
+        language="py",
+        docker_specs={},
+        namespace=None,
+    )
+
+
+def test_eval_script_starts_with_bash_strict_mode():
+    assert make_test_spec().eval_script.startswith(
+        f"#!/bin/bash\n{EVAL_SCRIPT_STRICT_MODE_HEADER}\n"
+    )
+
+
+def test_prepare_modal_eval_script_routes_xtrace_to_stdout():
+    prepared = prepare_modal_eval_script(
+        f"#!/bin/bash\n{EVAL_SCRIPT_STRICT_MODE_HEADER}\necho hi\n"
+    )
+    assert prepared.startswith(
+        f"#!/bin/bash\nBASH_XTRACEFD=1\n{EVAL_SCRIPT_STRICT_MODE_HEADER}\n"
+    )
+    assert "exec 2>&1" not in prepared
+    assert prepared.count("BASH_XTRACEFD=1\n") == 1
+
+
+def test_prepare_modal_eval_script_on_real_eval_script():
+    prepared = prepare_modal_eval_script(make_test_spec().eval_script)
+    assert prepared.startswith(
+        f"#!/bin/bash\nBASH_XTRACEFD=1\n{EVAL_SCRIPT_STRICT_MODE_HEADER}\n"
+    )
+
+
+def test_prepare_modal_eval_script_is_idempotent():
+    once = prepare_modal_eval_script(make_test_spec().eval_script)
+    twice = prepare_modal_eval_script(once)
+    assert once == twice
+    assert twice.count("BASH_XTRACEFD=1\n") == 1
+
+
+def test_get_logs_eval_parses_fixed_modal_output(tmp_path):
+    log_path = tmp_path / "test_output.txt"
+    log_path.write_text(
+        "+ git checkout abc123 tests/test_example.py\n"
+        "+ : '>>>>> Start Test Output'\n"
+        "+ pytest -rA\n"
+        "PASSED tests/test_example.py::test_ok\n"
+        "+ : '>>>>> End Test Output'\n"
+        "+ git checkout abc123 tests/test_example.py\n"
+    )
+
+    status_map, found = get_logs_eval(make_test_spec(), str(log_path))
+
+    assert found is True
+    assert status_map == {"tests/test_example.py::test_ok": _TestStatus.PASSED.value}


### PR DESCRIPTION
## Summary

Fixes SWE-bench/sb-cli#36. Non-django `gold` evaluations on Modal were reporting all tests as failed even though the tests passed. Root cause: Modal reads stdout/stderr separately and concatenates them (`run_evaluation_modal.py:137`), which pushed the `set -x` trace lines carrying the start/end markers to the tail of the log. `grading.py`'s marker-based slice then carved an empty region and no status map was produced.

This PR routes bash xtrace output to stdout via `BASH_XTRACEFD=1`, scoped to the Modal script prep only. Local Docker is untouched. Stderr of the test runner and its subprocesses is unaffected; only `set -x` trace output is redirected.

Diagnosis: @kingb12 ([comment](https://github.com/SWE-bench/sb-cli/issues/36#issuecomment-3218033541)). This is the narrower form of their second suggested fix.

## Changes

- `swebench/harness/test_spec/test_spec.py`: export `EVAL_SCRIPT_STRICT_MODE_HEADER` so Modal can target it without string duplication.
- `swebench/harness/modal_eval/utils.py`: new `prepare_modal_eval_script()` applies the existing django `locale-gen` hack plus the `BASH_XTRACEFD=1` injection.
- `swebench/harness/modal_eval/run_evaluation_modal.py`: call the helper instead of inline string manipulation.
- `tests/test_modal_eval.py`: regression coverage.

## Test plan

- [x] `pytest tests/test_modal_eval.py`, 5 passing (eval-script structure, Modal script prep, idempotency, `get_logs_eval` round-trip)
- [ ] Manual Modal repro per SWE-bench/sb-cli#36:
  ```
  python -m swebench.harness.run_evaluation \
      --dataset_name princeton-nlp/SWE-bench_Lite --split dev \
      --predictions_path gold --max_workers 8 \
      --run_id verify_447 --modal true \
      --instance_ids pydicom__pydicom-1256
  ```
  (Requires Modal credentials; not run locally.)

## Follow-ups (not in this PR)

- The fallback parse in `grading.py:86-89` was added to work around this same bug. Now redundant for the primary case; keep as defense-in-depth or remove in a separate PR.
- The real root cause is `"".join(stdout + stderr)` in `run_evaluation_modal.py:137`. Worth revisiting whether separating the streams is actually needed.