### PR TITLE
Fix Multilingual eval images leaking future commits and tags (closes #578)

### DIFF
--- a/swebench/harness/test_spec/utils.py
+++ b/swebench/harness/test_spec/utils.py
@@ -31,7 +31,17 @@ def make_repo_script_list_common(
         f"chmod -R 777 {repo_directory}",  # So nonroot user can run tests
         f"cd {repo_directory}",
         f"git reset --hard {base_commit}",
-        "git remote remove origin",  # Remove the remote so the agent won't see newer commits
+        # Remove the remote and tags so the agent won't see newer commits.
+        "git remote remove origin",
+        # Remove only tags pointing to commits after target timestamp
+        f"TARGET_TIMESTAMP=$(git show -s --format=%ci {base_commit})",
+        'git tag -l | while read tag; do TAG_COMMIT=$(git rev-list -n 1 "$tag"); TAG_TIME=$(git show -s --format=%ci "$TAG_COMMIT"); if [[ "$TAG_TIME" > "$TARGET_TIMESTAMP" ]]; then git tag -d "$tag"; fi; done',
+        "git reflog expire --expire=now --all",
+        "git gc --prune=now --aggressive",
+        # Verify future logs aren't available
+        "AFTER_TIMESTAMP=$(date -d \"$TARGET_TIMESTAMP + 1 second\" '+%Y-%m-%d %H:%M:%S')",
+        'COMMIT_COUNT=$(git log --oneline --all --since="$AFTER_TIMESTAMP" | wc -l)',
+        '[ "$COMMIT_COUNT" -eq 0 ] || exit 1',
     ]
     if "pre_install" in specs:
         setup_commands.extend(specs["pre_install"])


### PR DESCRIPTION
## Summary

**This PR closes a data-contamination leak in the Multilingual eval
container build path** that lets agents read the gold-patch fix
commit directly out of `.git/` and copy it verbatim into their model
output, inflating resolve rates without any actual reasoning.

### The problem

In the current SWE-bench harness, Multilingual eval containers
(Java/Go/Rust/JS/TS/C/C++/Ruby/PHP) ship with the **full upstream git
history including the fix commit**:

- Tags pointing to commits authored *after* `base_commit` are not deleted
- The reflog is not expired
- Unreachable objects are not pruned

So once an agent reads the PR number from `problem_statement`, a
single `git log --all --grep='#<PR>'` exposes the fix commit and
`git show <sha>` returns the gold patch verbatim. This is the same
attack vector filed in SWE-bench/swe-bench-multilingual-dockerfiles#10 by @ConnorBAdams (reproduced from the
issue: `axios__axios-4738` → `git log --all --grep='#4738'` →
`a11f950 Fix/4737/timeout error message for http (#4738)` →
`git show a11f950` → full gold patch).

In our internal audit of model runs on SWE-bench Multilingual (300
instances), session traces show agents literally invoking
`git log --all --grep` to retrieve the fix commit and copying its
diff into the model output, with measurable inflation in resolve
rates compared to the Python (Verified) path which is already clean.
Multilingual numbers across the field are therefore suspect until
this leak is closed.

### Why only Multilingual

The harness dispatches by file extension in `create_scripts.py`:

```python
func = {"py": make_repo_script_list_py}.get(ext, make_repo_script_list_common)
```

`make_repo_script_list_py` (`python.py:280-288`) already does the
cleanup — PR SWE-bench/SWE-bench#471 (merged) baked it in, and that PR description
explicitly notes "This currently only addresses the main SWE-bench
dataset. We should extend this to multilingual and multimodal
datasets soon." `make_repo_script_list_common` (`utils.py:22-36`),
the fall-through used for everything non-Python, never received the
same change.

### What this PR does

Copy the existing 9-line cleanup block from `python.py:280-288` into
`make_repo_script_list_common`, between `git remote remove origin`
and the `pre_install` block. **No new logic** — the inserted lines
are byte-for-byte identical to the Python path.

```
TARGET_TIMESTAMP=$(git show -s --format=%ci <base>)
git tag -l | while read tag; do … delete tags pointing past TARGET_TIMESTAMP … done
git reflog expire --expire=now --all
git gc --prune=now --aggressive
# verify zero future commits remain, or exit 1
```

Closes SWE-bench/swe-bench-multilingual-dockerfiles#10.
Related: SWE-bench/SWE-bench#465 (original future-commit issue), SWE-bench/SWE-bench#471 (Python-only fix).

## Why this is safe

- Python path unchanged: `create_scripts.py` dispatches `.py` repos
  to `python.py` and everything else to `utils.py`. Only the latter
  gains the cleanup; Python behavior is bit-identical.
- The added shell is the same shell `python.py` has been running for
  ~8 months without incident.

## Test plan

Verified end-to-end on two Multilingual instances by rebuilding the
eval images with this patched harness and re-running the attack
queries from SWE-bench/swe-bench-multilingual-dockerfiles#10's bug report:

|  | tokio-rs/tokio-6838 (Rust) | axios/axios-4738 (JS) |
|---|---|---|
| | unpatched → patched | unpatched → patched |
| `git rev-list HEAD.. --all \| wc -l` | 704 → **135** | 848 → **27** |
| `git log --all --grep='#<PR>' --oneline` | leaks `0cea36fa` → **(empty)** | leaks `a11f950` → **(empty)** |
| `git show <fix-SHA>` | succeeds → **unknown revision** | succeeds → **unknown revision** |
| `git show v1.9.0` (#578 attack) | n/a | succeeds → **unknown revision** |
| tag count | 383 → 341 (only ≤ base) | 136 → 59 (only ≤ base) |

The residual `HEAD.. --all` counts (135 / 27) are old side-branch
commits whose timestamps are all *before* base_commit — they are
topological orphans, not a future-knowledge leak (confirmed: max
timestamps 2022-01-31 and 2021-10-01 respectively, both pre-base).

To reproduce on any multilingual instance:

```bash
python -m swebench.harness.prepare_images \
    --dataset_name SWE-bench/SWE-bench_Multilingual --split test \
    --instance_ids <instance_id> \
    --tag latest --env_image_tag latest
docker run --rm sweb.eval.x86_64.<instance_id> bash -c \
    'cd /testbed && git log --all --grep="#<PR_num>" --oneline'   # expect empty
```

## Notes / follow-ups (out of scope for this PR)

- The inserted lines inherit the `%ci`-string-comparison timezone
  quirk that PR SWE-bench/SWE-bench#482 proposes to fix in `python.py`. When that lands,
  the same `%ct`-based replacement should be applied to both
  `python.py` and the new block in `utils.py` — a one-line follow-up.
- SWE-bench_Multimodal also routes through `utils.py` and would
  benefit from this same fix (#471 author's noted scope).
