### PR TITLE
fix: add per-instance spec overrides to handle astropy setuptools conflict

### DIFF
--- a/swebench/harness/constants/__init__.py
+++ b/swebench/harness/constants/__init__.py
@@ -144,6 +144,22 @@ MAP_REPO_VERSION_TO_SPECS = {
     **MAP_REPO_VERSION_TO_SPECS_RUST,
 }
 
+# Per-instance spec overrides. These are shallow-merged on top of the
+# repo-version-level spec in make_test_spec(), allowing individual instances
+# to override specific keys (e.g. pip_packages, pre_install) without affecting
+# other instances of the same repo/version.
+MAP_INSTANCE_TO_SPECS = {
+    # astropy__astropy-8872: setuptools >= 60 ships a vendored distutils whose
+    # LooseVersion emits a DeprecationWarning. astropy 3.1's pytest config
+    # escalates warnings to errors, causing test collection to abort before any
+    # test runs. Pin setuptools < 60 to use the stdlib distutils instead.
+    "astropy__astropy-8872": {
+        "pre_install": [
+            "python -m pip install 'setuptools<60'",
+        ],
+    },
+}
+
 MAP_REPO_TO_INSTALL = {
     **MAP_REPO_TO_INSTALL_C,
     **MAP_REPO_TO_INSTALL_GO,

--- a/swebench/harness/test_spec/test_spec.py
+++ b/swebench/harness/test_spec/test_spec.py
@@ -8,6 +8,7 @@ from swebench.harness.constants import (
     DEFAULT_DOCKER_SPECS,
     KEY_INSTANCE_ID,
     LATEST,
+    MAP_INSTANCE_TO_SPECS,
     MAP_REPO_TO_EXT,
     MAP_REPO_VERSION_TO_SPECS,
     SWEbenchInstance,
@@ -207,6 +208,12 @@ def make_test_spec(
     env_name = "testbed"
     repo_directory = f"/{env_name}"
     specs = MAP_REPO_VERSION_TO_SPECS[repo][version]
+
+    # Apply per-instance spec overrides if present
+    instance_overrides = MAP_INSTANCE_TO_SPECS.get(instance_id, {})
+    if instance_overrides:
+        specs = {**specs, **instance_overrides}
+
     docker_specs = specs.get("docker_specs", {})
 
     repo_script_list = make_repo_script_list(


### PR DESCRIPTION
## Summary

Fixes #584 — the gold patch for `astropy__astropy-8872` cannot be scored because `setuptools==68.0.0` (from the repo-version spec) ships a vendored `distutils` whose `LooseVersion` emits a `DeprecationWarning`. Astropy 3.1's pytest config escalates warnings to errors, causing test collection to abort before any test runs.

## Changes

1. **New `MAP_INSTANCE_TO_SPECS` dictionary** in `swebench/harness/constants/__init__.py` — a per-instance override layer that is shallow-merged on top of the repo-version-level spec in `make_test_spec()`. Only the keys that need changing need to be provided.

2. **Override logic in `make_test_spec()`** — after fetching `specs` from `MAP_REPO_VERSION_TO_SPECS`, checks `MAP_INSTANCE_TO_SPECS` for the current `instance_id` and applies any overrides via `{**specs, **instance_overrides}`.

3. **Instance override for `astropy__astropy-8872`** — adds a `pre_install` step that runs `python -m pip install 'setuptools<60'` to downgrade setuptools before astropy is installed. This uses the stdlib `distutils` (which does not emit the `LooseVersion` warning on Python 3.9) instead of the vendored copy.

## Testing

- Unit tests (`tests/test_harness_utils.py`) pass.
- Verified that `make_test_spec` produces a repo install script containing the `setuptools<60` pin for `astropy__astropy-8872`.
- The override is zero-blast-radius: it only affects the single instance. All other astropy 3.1 instances continue to use `setuptools==68.0.0` as before.
