### PR TITLE
Fix pytest skipped test grading

### DIFF
--- a/swebench/harness/grading.py
+++ b/swebench/harness/grading.py
@@ -28,10 +28,17 @@ def test_passed(case: str, sm: dict[str, str]) -> bool:
     return case in sm and sm[case] in [TestStatus.PASSED.value, TestStatus.XFAIL.value]
 
 
+def test_maintained(case: str, sm: dict[str, str]) -> bool:
+    return test_passed(case, sm) or (
+        case in sm and sm[case] == TestStatus.SKIPPED.value
+    )
+
+
 def test_failed(case: str, sm: dict[str, str]) -> bool:
     return case not in sm or sm[case] in [
         TestStatus.FAILED.value,
         TestStatus.ERROR.value,
+        TestStatus.SKIPPED.value,
     ]
 
 
@@ -150,7 +157,13 @@ def get_eval_tests_report(
     p2p_success = []
     p2p_failure = []
     for test_case in gold_results[PASS_TO_PASS]:
-        check_test_case(test_case, eval_status_map, p2p_success, p2p_failure)
+        if eval_type == EvalType.PASS_AND_FAIL:
+            if test_maintained(test_case, eval_status_map):
+                p2p_success.append(test_case)
+            elif test_failed(test_case, eval_status_map):
+                p2p_failure.append(test_case)
+        else:
+            check_test_case(test_case, eval_status_map, p2p_success, p2p_failure)
 
     results = {
         FAIL_TO_PASS: {

--- a/swebench/harness/grading.py
+++ b/swebench/harness/grading.py
@@ -24,10 +24,17 @@ def test_passed(case: str, sm: dict[str, str]) -> bool:
     return case in sm and sm[case] in [TestStatus.PASSED.value, TestStatus.XFAIL.value]
 
 
+def test_maintained(case: str, sm: dict[str, str]) -> bool:
+    return test_passed(case, sm) or (
+        case in sm and sm[case] == TestStatus.SKIPPED.value
+    )
+
+
 def test_failed(case: str, sm: dict[str, str]) -> bool:
     return case not in sm or sm[case] in [
         TestStatus.FAILED.value,
         TestStatus.ERROR.value,
+        TestStatus.SKIPPED.value,
     ]
 
 
@@ -130,7 +137,13 @@ def get_eval_tests_report(
     p2p_success = []
     p2p_failure = []
     for test_case in gold_results[PASS_TO_PASS]:
-        check_test_case(test_case, eval_status_map, p2p_success, p2p_failure)
+        if eval_type == EvalType.PASS_AND_FAIL:
+            if test_maintained(test_case, eval_status_map):
+                p2p_success.append(test_case)
+            elif test_failed(test_case, eval_status_map):
+                p2p_failure.append(test_case)
+        else:
+            check_test_case(test_case, eval_status_map, p2p_success, p2p_failure)
 
     results = {
         FAIL_TO_PASS: {

--- a/swebench/harness/log_parsers/python.py
+++ b/swebench/harness/log_parsers/python.py
@@ -4,6 +4,27 @@ from swebench.harness.constants import TestStatus
 from swebench.harness.test_spec.test_spec import TestSpec
 
 
+def _parse_pytest_result_line(line: str) -> tuple[str, str] | None:
+    """Parse pytest result lines without treating skip summaries as tests."""
+    statuses = "|".join(status.value for status in TestStatus)
+
+    status_first = re.match(rf"^({statuses})\s+(\S+)", line)
+    if status_first:
+        status, test_name = status_first.groups()
+        if status == TestStatus.FAILED.value:
+            test_name = line.replace(" - ", " ").split()[1]
+        if status == TestStatus.SKIPPED.value and re.match(r"\[\d+\]", test_name):
+            return None
+        return test_name, status
+
+    test_first = re.match(rf"^(\S+)\s+({statuses})(?:\s|$)", line)
+    if test_first:
+        test_name, status = test_first.groups()
+        return test_name, status
+
+    return None
+
+
 def parse_log_pytest(log: str, test_spec: TestSpec) -> dict[str, str]:
     """
     Parser for test logs generated with PyTest framework
@@ -15,15 +36,24 @@ def parse_log_pytest(log: str, test_spec: TestSpec) -> dict[str, str]:
     """
     test_status_map = {}
     for line in log.split("\n"):
-        if any([line.startswith(x.value) for x in TestStatus]):
-            # Additional parsing for FAILED status
-            if line.startswith(TestStatus.FAILED.value):
-                line = line.replace(" - ", " ")
-            test_case = line.split()
-            if len(test_case) <= 1:
-                continue
-            test_status_map[test_case[1]] = test_case[0]
+        parsed = _parse_pytest_result_line(line)
+        if parsed is None:
+            continue
+        test_case, status = parsed
+        test_status_map[test_case] = status
     return test_status_map
+
+
+def _normalize_pytest_option_test_name(test_name: str) -> str:
+    option_pattern = re.compile(r"(.*?)\[(.*)\]")
+    has_option = option_pattern.search(test_name)
+    if not has_option:
+        return test_name
+
+    main, option = has_option.groups()
+    if option.startswith("/") and not option.startswith("//") and "*" not in option:
+        option = "/" + option.split("/")[-1]
+    return f"{main}[{option}]"
 
 
 def parse_log_pytest_options(log: str, test_spec: TestSpec) -> dict[str, str]:
@@ -35,29 +65,13 @@ def parse_log_pytest_options(log: str, test_spec: TestSpec) -> dict[str, str]:
     Returns:
         dict: test case to test status mapping
     """
-    option_pattern = re.compile(r"(.*?)\[(.*)\]")
     test_status_map = {}
     for line in log.split("\n"):
-        if any([line.startswith(x.value) for x in TestStatus]):
-            # Additional parsing for FAILED status
-            if line.startswith(TestStatus.FAILED.value):
-                line = line.replace(" - ", " ")
-            test_case = line.split()
-            if len(test_case) <= 1:
-                continue
-            has_option = option_pattern.search(test_case[1])
-            if has_option:
-                main, option = has_option.groups()
-                if (
-                    option.startswith("/")
-                    and not option.startswith("//")
-                    and "*" not in option
-                ):
-                    option = "/" + option.split("/")[-1]
-                test_name = f"{main}[{option}]"
-            else:
-                test_name = test_case[1]
-            test_status_map[test_name] = test_case[0]
+        parsed = _parse_pytest_result_line(line)
+        if parsed is None:
+            continue
+        test_case, status = parsed
+        test_status_map[_normalize_pytest_option_test_name(test_case)] = status
     return test_status_map
 
 
@@ -156,17 +170,11 @@ def parse_log_pytest_v2(log: str, test_spec: TestSpec) -> dict[str, str]:
         line = re.sub(r"\[(\d+)m", "", line)
         translator = str.maketrans("", "", escapes)
         line = line.translate(translator)
-        if any([line.startswith(x.value) for x in TestStatus]):
-            if line.startswith(TestStatus.FAILED.value):
-                line = line.replace(" - ", " ")
-            test_case = line.split()
-            if len(test_case) >= 2:
-                test_status_map[test_case[1]] = test_case[0]
-        # Support older pytest versions by checking if the line ends with the test status
-        elif any([line.endswith(x.value) for x in TestStatus]):
-            test_case = line.split()
-            if len(test_case) >= 2:
-                test_status_map[test_case[0]] = test_case[1]
+        parsed = _parse_pytest_result_line(line)
+        if parsed is None:
+            continue
+        test_case, status = parsed
+        test_status_map[test_case] = status
     return test_status_map
 
 

--- a/swebench/harness/log_parsers/python.py
+++ b/swebench/harness/log_parsers/python.py
@@ -4,20 +4,24 @@ from swebench.harness.constants import TestStatus
 from swebench.harness.test_spec.test_spec import TestSpec
 
 
+_PYTEST_STATUS_PATTERN = "|".join(re.escape(status.value) for status in TestStatus)
+_PYTEST_STATUS_FIRST = re.compile(rf"^({_PYTEST_STATUS_PATTERN})\s+(\S+)")
+_PYTEST_TEST_FIRST = re.compile(rf"^(\S+)\s+({_PYTEST_STATUS_PATTERN})(?:\s|$)")
+_PYTEST_SKIP_COUNT = re.compile(r"\[\d+\]")
+
+
 def _parse_pytest_result_line(line: str) -> tuple[str, str] | None:
     """Parse pytest result lines without treating skip summaries as tests."""
-    statuses = "|".join(status.value for status in TestStatus)
-
-    status_first = re.match(rf"^({statuses})\s+(\S+)", line)
+    status_first = _PYTEST_STATUS_FIRST.match(line)
     if status_first:
         status, test_name = status_first.groups()
         if status == TestStatus.FAILED.value:
             test_name = line.replace(" - ", " ").split()[1]
-        if status == TestStatus.SKIPPED.value and re.match(r"\[\d+\]", test_name):
+        if status == TestStatus.SKIPPED.value and _PYTEST_SKIP_COUNT.match(test_name):
             return None
         return test_name, status
 
-    test_first = re.match(rf"^(\S+)\s+({statuses})(?:\s|$)", line)
+    test_first = _PYTEST_TEST_FIRST.match(line)
     if test_first:
         test_name, status = test_first.groups()
         return test_name, status

--- a/swebench/harness/log_parsers/python.py
+++ b/swebench/harness/log_parsers/python.py
@@ -4,6 +4,27 @@ from swebench.harness.constants import TestStatus
 from swebench.types import TestSpec
 
 
+def _parse_pytest_result_line(line: str) -> tuple[str, str] | None:
+    """Parse pytest result lines without treating skip summaries as tests."""
+    statuses = "|".join(status.value for status in TestStatus)
+
+    status_first = re.match(rf"^({statuses})\s+(\S+)", line)
+    if status_first:
+        status, test_name = status_first.groups()
+        if status == TestStatus.FAILED.value:
+            test_name = line.replace(" - ", " ").split()[1]
+        if status == TestStatus.SKIPPED.value and re.match(r"\[\d+\]", test_name):
+            return None
+        return test_name, status
+
+    test_first = re.match(rf"^(\S+)\s+({statuses})(?:\s|$)", line)
+    if test_first:
+        test_name, status = test_first.groups()
+        return test_name, status
+
+    return None
+
+
 def parse_log_pytest(log: str, test_spec: TestSpec) -> dict[str, str]:
     """
     Parser for test logs generated with PyTest framework
@@ -15,15 +36,24 @@ def parse_log_pytest(log: str, test_spec: TestSpec) -> dict[str, str]:
     """
     test_status_map = {}
     for line in log.split("\n"):
-        if any([line.startswith(x.value) for x in TestStatus]):
-            # Additional parsing for FAILED status
-            if line.startswith(TestStatus.FAILED.value):
-                line = line.replace(" - ", " ")
-            test_case = line.split()
-            if len(test_case) <= 1:
-                continue
-            test_status_map[test_case[1]] = test_case[0]
+        parsed = _parse_pytest_result_line(line)
+        if parsed is None:
+            continue
+        test_case, status = parsed
+        test_status_map[test_case] = status
     return test_status_map
+
+
+def _normalize_pytest_option_test_name(test_name: str) -> str:
+    option_pattern = re.compile(r"(.*?)\[(.*)\]")
+    has_option = option_pattern.search(test_name)
+    if not has_option:
+        return test_name
+
+    main, option = has_option.groups()
+    if option.startswith("/") and not option.startswith("//") and "*" not in option:
+        option = "/" + option.split("/")[-1]
+    return f"{main}[{option}]"
 
 
 def parse_log_pytest_options(log: str, test_spec: TestSpec) -> dict[str, str]:
@@ -35,29 +65,13 @@ def parse_log_pytest_options(log: str, test_spec: TestSpec) -> dict[str, str]:
     Returns:
         dict: test case to test status mapping
     """
-    option_pattern = re.compile(r"(.*?)\[(.*)\]")
     test_status_map = {}
     for line in log.split("\n"):
-        if any([line.startswith(x.value) for x in TestStatus]):
-            # Additional parsing for FAILED status
-            if line.startswith(TestStatus.FAILED.value):
-                line = line.replace(" - ", " ")
-            test_case = line.split()
-            if len(test_case) <= 1:
-                continue
-            has_option = option_pattern.search(test_case[1])
-            if has_option:
-                main, option = has_option.groups()
-                if (
-                    option.startswith("/")
-                    and not option.startswith("//")
-                    and "*" not in option
-                ):
-                    option = "/" + option.split("/")[-1]
-                test_name = f"{main}[{option}]"
-            else:
-                test_name = test_case[1]
-            test_status_map[test_name] = test_case[0]
+        parsed = _parse_pytest_result_line(line)
+        if parsed is None:
+            continue
+        test_case, status = parsed
+        test_status_map[_normalize_pytest_option_test_name(test_case)] = status
     return test_status_map
 
 
@@ -156,17 +170,11 @@ def parse_log_pytest_v2(log: str, test_spec: TestSpec) -> dict[str, str]:
         line = re.sub(r"\[(\d+)m", "", line)
         translator = str.maketrans("", "", escapes)
         line = line.translate(translator)
-        if any([line.startswith(x.value) for x in TestStatus]):
-            if line.startswith(TestStatus.FAILED.value):
-                line = line.replace(" - ", " ")
-            test_case = line.split()
-            if len(test_case) >= 2:
-                test_status_map[test_case[1]] = test_case[0]
-        # Support older pytest versions by checking if the line ends with the test status
-        elif any([line.endswith(x.value) for x in TestStatus]):
-            test_case = line.split()
-            if len(test_case) >= 2:
-                test_status_map[test_case[0]] = test_case[1]
+        parsed = _parse_pytest_result_line(line)
+        if parsed is None:
+            continue
+        test_case, status = parsed
+        test_status_map[test_case] = status
     return test_status_map
 
 

--- a/swebench/harness/log_parsers/python.py
+++ b/swebench/harness/log_parsers/python.py
@@ -4,20 +4,24 @@ from swebench.harness.constants import TestStatus
 from swebench.types import TestSpec
 
 
+_PYTEST_STATUS_PATTERN = "|".join(re.escape(status.value) for status in TestStatus)
+_PYTEST_STATUS_FIRST = re.compile(rf"^({_PYTEST_STATUS_PATTERN})\s+(\S+)")
+_PYTEST_TEST_FIRST = re.compile(rf"^(\S+)\s+({_PYTEST_STATUS_PATTERN})(?:\s|$)")
+_PYTEST_SKIP_COUNT = re.compile(r"\[\d+\]")
+
+
 def _parse_pytest_result_line(line: str) -> tuple[str, str] | None:
     """Parse pytest result lines without treating skip summaries as tests."""
-    statuses = "|".join(status.value for status in TestStatus)
-
-    status_first = re.match(rf"^({statuses})\s+(\S+)", line)
+    status_first = _PYTEST_STATUS_FIRST.match(line)
     if status_first:
         status, test_name = status_first.groups()
         if status == TestStatus.FAILED.value:
             test_name = line.replace(" - ", " ").split()[1]
-        if status == TestStatus.SKIPPED.value and re.match(r"\[\d+\]", test_name):
+        if status == TestStatus.SKIPPED.value and _PYTEST_SKIP_COUNT.match(test_name):
             return None
         return test_name, status
 
-    test_first = re.match(rf"^(\S+)\s+({statuses})(?:\s|$)", line)
+    test_first = _PYTEST_TEST_FIRST.match(line)
     if test_first:
         test_name, status = test_first.groups()
         return test_name, status

--- a/tests/test_grading.py
+++ b/tests/test_grading.py
@@ -1,12 +1,16 @@
-from swebench.harness.constants import FAIL_TO_PASS, PASS_TO_PASS, TestStatus
+from swebench.harness.constants import (
+    FAIL_TO_PASS,
+    PASS_TO_PASS,
+    TestStatus as _TestStatus,
+)
 from swebench.harness.grading import get_eval_tests_report
 
 
 def test_skipped_pass_to_pass_tests_are_maintained() -> None:
     report = get_eval_tests_report(
         {
-            "test_fix": TestStatus.SKIPPED.value,
-            "test_maintenance": TestStatus.SKIPPED.value,
+            "test_fix": _TestStatus.SKIPPED.value,
+            "test_maintenance": _TestStatus.SKIPPED.value,
         },
         {
             FAIL_TO_PASS: ["test_fix"],

--- a/tests/test_grading.py
+++ b/tests/test_grading.py
@@ -1,0 +1,19 @@
+from swebench.harness.constants import FAIL_TO_PASS, PASS_TO_PASS, TestStatus
+from swebench.harness.grading import get_eval_tests_report
+
+
+def test_skipped_pass_to_pass_tests_are_maintained() -> None:
+    report = get_eval_tests_report(
+        {
+            "test_fix": TestStatus.SKIPPED.value,
+            "test_maintenance": TestStatus.SKIPPED.value,
+        },
+        {
+            FAIL_TO_PASS: ["test_fix"],
+            PASS_TO_PASS: ["test_maintenance"],
+        },
+    )
+
+    assert report[FAIL_TO_PASS]["failure"] == ["test_fix"]
+    assert report[PASS_TO_PASS]["success"] == ["test_maintenance"]
+    assert report[PASS_TO_PASS]["failure"] == []

--- a/tests/test_log_parsers_python.py
+++ b/tests/test_log_parsers_python.py
@@ -1,0 +1,25 @@
+from swebench.harness.constants import TestStatus
+from swebench.harness.log_parsers.python import parse_log_pytest_options
+
+
+def test_parse_pytest_skipped_verbose_nodeid() -> None:
+    log = "\n".join(
+        [
+            "tests/lint/unittest_lint.py::LintRunTC::test_jobs_option SKIPPED [1] Need 2 or more cores",
+            "SKIPPED [1] tests/lint/unittest_lint.py:774: Need 2 or more cores",
+        ]
+    )
+
+    result = parse_log_pytest_options(log, None)
+
+    assert result == {
+        "tests/lint/unittest_lint.py::LintRunTC::test_jobs_option": (
+            TestStatus.SKIPPED.value
+        )
+    }
+
+
+def test_parse_pytest_skipped_summary_without_nodeid_is_ignored() -> None:
+    log = "SKIPPED [1] tests/lint/unittest_lint.py:774: Need 2 or more cores"
+
+    assert parse_log_pytest_options(log, None) == {}

--- a/tests/test_log_parsers_python.py
+++ b/tests/test_log_parsers_python.py
@@ -1,5 +1,25 @@
-from swebench.harness.constants import TestStatus
-from swebench.harness.log_parsers.python import parse_log_pytest_options
+import pytest
+
+from swebench.harness.constants import (
+    FAIL_TO_PASS,
+    PASS_TO_PASS,
+    ResolvedStatus,
+    TestStatus as _TestStatus,
+)
+from swebench.harness.grading import get_eval_tests_report, get_resolution_status
+from swebench.harness.log_parsers.python import (
+    parse_log_pytest,
+    parse_log_pytest_options,
+    parse_log_pytest_v2,
+)
+
+
+PYLINT_6528_SKIPPED_TESTS = [
+    "tests/lint/unittest_lint.py::test_custom_should_analyze_file",
+    "tests/lint/unittest_lint.py::test_multiprocessing[1]",
+    "tests/lint/unittest_lint.py::test_multiprocessing[2]",
+    "tests/test_self.py::TestRunTC::test_jobs_score",
+]
 
 
 def test_parse_pytest_skipped_verbose_nodeid() -> None:
@@ -14,7 +34,7 @@ def test_parse_pytest_skipped_verbose_nodeid() -> None:
 
     assert result == {
         "tests/lint/unittest_lint.py::LintRunTC::test_jobs_option": (
-            TestStatus.SKIPPED.value
+            _TestStatus.SKIPPED.value
         )
     }
 
@@ -23,3 +43,56 @@ def test_parse_pytest_skipped_summary_without_nodeid_is_ignored() -> None:
     log = "SKIPPED [1] tests/lint/unittest_lint.py:774: Need 2 or more cores"
 
     assert parse_log_pytest_options(log, None) == {}
+
+
+@pytest.mark.parametrize(
+    "parser", [parse_log_pytest, parse_log_pytest_options, parse_log_pytest_v2]
+)
+def test_parse_pytest_supports_status_before_and_after_nodeid(parser) -> None:
+    log = "\n".join(
+        [
+            "PASSED tests/test_widget.py::test_create",
+            "tests/test_widget.py::test_delete FAILED [100%]",
+        ]
+    )
+
+    assert parser(log, None) == {
+        "tests/test_widget.py::test_create": _TestStatus.PASSED.value,
+        "tests/test_widget.py::test_delete": _TestStatus.FAILED.value,
+    }
+
+
+def test_pylint_6528_single_core_skips_do_not_cause_false_regression() -> None:
+    fail_to_pass = [
+        "tests/lint/unittest_lint.py::test_recursive_ignore[--ignore-ignored_subdirectory]",
+        "tests/lint/unittest_lint.py::test_recursive_ignore[--ignore-patterns-ignored_*]",
+        "tests/test_self.py::TestRunTC::test_ignore_recursive",
+        "tests/test_self.py::TestRunTC::test_ignore_pattern_recursive",
+    ]
+    log = "\n".join(
+        [
+            *(f"{test} PASSED" for test in fail_to_pass),
+            f"{PYLINT_6528_SKIPPED_TESTS[0]} SKIPPED [1] Need 2 or more cores",
+            f"{PYLINT_6528_SKIPPED_TESTS[1]} SKIPPED [1] Need 2 or more cores",
+            f"{PYLINT_6528_SKIPPED_TESTS[2]} SKIPPED [1] Need 2 or more cores",
+            f"{PYLINT_6528_SKIPPED_TESTS[3]} SKIPPED [1] Need 2 or more cores",
+            "SKIPPED [1] tests/lint/unittest_lint.py:774: Need 2 or more cores",
+            "SKIPPED [2] tests/lint/unittest_lint.py:803: Need 2 or more cores",
+            "SKIPPED [1] tests/test_self.py:1050: Need 2 or more cores",
+            "2 failed, 171 passed, 4 skipped, 1 xfailed",
+        ]
+    )
+
+    status_map = parse_log_pytest_options(log, None)
+    report = get_eval_tests_report(
+        status_map,
+        {FAIL_TO_PASS: fail_to_pass, PASS_TO_PASS: PYLINT_6528_SKIPPED_TESTS},
+    )
+
+    assert all(
+        status_map[test] == _TestStatus.SKIPPED.value
+        for test in PYLINT_6528_SKIPPED_TESTS
+    )
+    assert "[1]" not in status_map
+    assert "[2]" not in status_map
+    assert get_resolution_status(report) == ResolvedStatus.FULL.value


### PR DESCRIPTION
## Summary

- Parse pytest `nodeid SKIPPED ...` result lines so skipped tests retain their real node ID.
- Ignore pytest `SKIPPED [N] path:line: reason` summary lines instead of recording `[N]` as a fake test.
- Count skipped FAIL_TO_PASS tests as failures while treating skipped PASS_TO_PASS tests as maintained.
- Rebase the focused parser and grading fix onto current `main` after the harness restructure.

Fixes SWE-bench/sb-cli#29.

## Validation

- `python -m pytest -vv tests/test_log_parsers_python.py tests/test_grading.py` — 7 passed.
- `python -m pytest --cov -k "not test_one_instance"` — 20 passed, 1 deselected.
- `pre-commit run --files swebench/harness/grading.py swebench/harness/log_parsers/python.py tests/test_grading.py tests/test_log_parsers_python.py` — ruff and ruff-format passed.
- `git diff --check upstream/main...HEAD`.

The deselected repository test is the network-backed gold evaluation for `sympy__sympy-20590`. It reached the remote dataset request but stalled in a TLS handshake on this macOS host; PR CI remains the authoritative run for that external evaluation path.