### PR TITLE
Fix clone URL for SWE-bench repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you're setting up on Linux, we recommend seeing the [post-installation steps]
 
 Finally, to build SWE-bench from source, follow these steps:
 ```bash
-git clone git@github.com:princeton-nlp/SWE-bench.git
+git clone git@github.com:SWE-bench/SWE-bench.git
 cd SWE-bench
 pip install -e .
 ```


### PR DESCRIPTION
Updated the GitHub repository URL for cloning SWE-bench, old one wasn't working. Someone should check other search results for `princeton-nlp`: https://github.com/search?q=repo%3ASWE-bench%2FSWE-bench%20princeton-nlp&type=code

<!--
Thanks for contributing a pull request!
-->


#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->
Old repo url => new repo url
