### PR TITLE
Fix IndexError in parse_log_seaborn on bare status lines

### DIFF
--- a/swebench/harness/log_parsers/python.py
+++ b/swebench/harness/log_parsers/python.py
@@ -181,16 +181,17 @@ def parse_log_seaborn(log: str, test_spec: TestSpec) -> dict[str, str]:
     """
     test_status_map = {}
     for line in log.split("\n"):
+        parts = line.split()
+        if len(parts) < 2:
+            continue
         if line.startswith(TestStatus.FAILED.value):
-            test_case = line.split()[1]
+            test_case = parts[1]
             test_status_map[test_case] = TestStatus.FAILED.value
         elif f" {TestStatus.PASSED.value} " in line:
-            parts = line.split()
             if parts[1] == TestStatus.PASSED.value:
                 test_case = parts[0]
                 test_status_map[test_case] = TestStatus.PASSED.value
         elif line.startswith(TestStatus.PASSED.value):
-            parts = line.split()
             test_case = parts[1]
             test_status_map[test_case] = TestStatus.PASSED.value
     return test_status_map

--- a/tests/test_log_parsers_python.py
+++ b/tests/test_log_parsers_python.py
@@ -1,0 +1,38 @@
+from swebench.harness.log_parsers.python import parse_log_seaborn
+from swebench.harness.constants import TestStatus
+
+
+class TestParseLogSeaborn:
+    """Tests for parse_log_seaborn used by mwaskom/seaborn."""
+
+    def test_parse_pass_and_fail(self):
+        """Test parsing the three supported line formats."""
+        log = """\
+test_a.py::test_one PASSED [ 50%]
+PASSED test_b.py::test_two
+FAILED test_c.py::test_three
+"""
+        result = parse_log_seaborn(log, test_spec=None)
+
+        assert result == {
+            "test_a.py::test_one": TestStatus.PASSED.value,
+            "test_b.py::test_two": TestStatus.PASSED.value,
+            "test_c.py::test_three": TestStatus.FAILED.value,
+        }
+
+    def test_bare_status_lines_do_not_crash(self):
+        """Status words on their own line (e.g. interleaved/captured output)
+        must be ignored rather than raising IndexError."""
+        log = """\
+test_a.py::test_one PASSED [ 50%]
+PASSED
+FAILED
+ PASSED
+test_b.py::test_two PASSED [100%]
+"""
+        result = parse_log_seaborn(log, test_spec=None)
+
+        assert result == {
+            "test_a.py::test_one": TestStatus.PASSED.value,
+            "test_b.py::test_two": TestStatus.PASSED.value,
+        }


### PR DESCRIPTION
## What's broken
`parse_log_seaborn` (used to grade `mwaskom/seaborn` instances) indexes `line.split()[1]` / `parts[1]` without a length check. A log line that is just a bare status word — e.g. `PASSED` or `FAILED` on its own line, common when test output is interleaved or captured stdout contains the word — raises `IndexError`, which propagates out of `get_logs_eval` (`grading.py`) and crashes grading for that instance.
parse_log_seaborn("tests/test_x.py::test_a PASSED\nPASSED\n") # IndexError

## Why it happens
Missing length guard before positional indexing of `line.split()`, inconsistent with the sibling `parse_log_pytest`, which guards this exact case with `if len(test_case) <= 1: continue`.
## Fix
Compute `parts = line.split()` once and `continue` when `len(parts) < 2`, matching the other pytest-family parsers. Valid-line parsing is unchanged.
## Test
Added `tests/test_log_parsers_python.py` feeding bare `PASSED`/`FAILED` lines (crashes before, parses cleanly after); valid output byte-identical. Mirrors the existing interleaved-logs test for the Java parser.