### PR TITLE
Filter Django test directives to test files

### DIFF
--- a/swebench/harness/test_spec/python.py
+++ b/swebench/harness/test_spec/python.py
@@ -252,6 +252,8 @@ def get_test_directives(instance: SWEbenchInstance) -> list:
     if instance["repo"] == "django/django":
         directives_transformed = []
         for d in directives:
+            if not is_django_test_file(d):
+                continue
             d = d[: -len(".py")] if d.endswith(".py") else d
             d = d[len("tests/") :] if d.startswith("tests/") else d
             d = d.replace("/", ".")
@@ -259,6 +261,16 @@ def get_test_directives(instance: SWEbenchInstance) -> list:
         directives = directives_transformed
 
     return directives
+
+
+def is_django_test_file(path: str) -> bool:
+    file_name = posixpath.basename(path)
+    return (
+        file_name == "tests.py"
+        or file_name.startswith("test_")
+        or "/tests/" in path
+        or "/test_" in path
+    )
 
 
 def make_repo_script_list_py(

--- a/tests/test_harness_utils.py
+++ b/tests/test_harness_utils.py
@@ -1,9 +1,59 @@
 import unittest
 from swebench.harness.utils import run_threadpool
-from swebench.harness.test_spec.python import clean_environment_yml, clean_requirements
+from swebench.harness.test_spec.python import (
+    clean_environment_yml,
+    clean_requirements,
+    get_test_directives,
+)
 
 
 class UtilTests(unittest.TestCase):
+    def test_django_test_directives_ignore_non_test_modules(self):
+        test_patch = (
+            "diff --git a/tests/file_storage/models.py "
+            "b/tests/file_storage/models.py\n"
+            "--- a/tests/file_storage/models.py\n"
+            "+++ b/tests/file_storage/models.py\n"
+            "@@ -1,3 +1,6 @@\n"
+            " from django.db import models\n"
+            "+def callable_default_storage():\n"
+            "+    return default_storage\n"
+            "diff --git a/tests/file_storage/tests.py "
+            "b/tests/file_storage/tests.py\n"
+            "--- a/tests/file_storage/tests.py\n"
+            "+++ b/tests/file_storage/tests.py\n"
+            "@@ -10,6 +10,9 @@\n"
+            " class FileFieldDeconstructionTests(SimpleTestCase):\n"
+            "+    def test_callable_default_storage_deconstruction(self):\n"
+            "+        pass\n"
+        )
+        instance = {"repo": "django/django", "test_patch": test_patch}
+
+        directives = get_test_directives(instance)
+
+        self.assertEqual(directives, ["file_storage.tests"])
+
+    def test_python_test_directives_keep_changed_python_files(self):
+        test_patch = (
+            "diff --git a/src/package/models.py b/src/package/models.py\n"
+            "--- a/src/package/models.py\n"
+            "+++ b/src/package/models.py\n"
+            "@@ -1 +1 @@\n"
+            "-VALUE = 1\n"
+            "+VALUE = 2\n"
+            "diff --git a/tests/test_models.py b/tests/test_models.py\n"
+            "--- a/tests/test_models.py\n"
+            "+++ b/tests/test_models.py\n"
+            "@@ -1 +1 @@\n"
+            "-def test_value(): pass\n"
+            "+def test_value(): pass\n"
+        )
+        instance = {"repo": "example/project", "test_patch": test_patch}
+
+        directives = get_test_directives(instance)
+
+        self.assertEqual(directives, ["src/package/models.py", "tests/test_models.py"])
+
     def test_run_threadpool_all_failures(self):
         def failing_func(_):
             raise ValueError("Test error")


### PR DESCRIPTION
## Summary

- Filter Django test directives so only test-looking files are passed to `runtests.py`.
- Preserve module-level directives for Django test modules.
- Add regression coverage for a Django patch that changes both a support module and a test module.

## Changes

`get_test_directives()` currently derives Python directives from every changed `.py` file in `test_patch`. For Django, those paths are converted to dotted `runtests.py` labels.

That can turn a changed support module such as `tests/file_storage/models.py` into `file_storage.models`, even though it is not a Django test module. Django's test runner treats dotted labels as importable modules or `module.Class.method` names, so a non-test support module can create loader failures instead of selecting the intended tests.

This change filters Django directives to files that look like test files before converting them to dotted labels. It keeps module-level labels such as `file_storage.tests`, `admin_views.tests`, and `forms_tests.field_tests.test_datefield`, so existing pass-to-pass coverage remains module-level.

Part of SWE-bench/swe-bench-dockerfiles#21.

This PR addresses the non-test-file directive case; it does not attempt to classify every eval-brittle pattern discussed in SWE-bench/swe-bench-dockerfiles#21.

## Verification

```bash
pytest tests/test_harness_utils.py
```

Directive generation was also checked for the Django instances listed in SWE-bench/swe-bench-dockerfiles#21 from `SWE-bench/SWE-bench_Verified`; `django__django-16493` now maps to `file_storage.tests`, while the other sampled instances preserve module-level test directives.
