### PR TITLE
Fix inconsistent test name whitespace in parse_log_jest

### DIFF
--- a/swebench/harness/log_parsers/javascript.py
+++ b/swebench/harness/log_parsers/javascript.py
@@ -196,6 +196,7 @@ def parse_log_jest(log: str, test_spec: TestSpec) -> dict[str, str]:
         match = re.match(pattern, line.strip())
         if match:
             status_symbol, test_name, _duration = match.groups()
+            test_name = test_name.strip()
             if status_symbol == "✓":
                 test_status_map[test_name] = TestStatus.PASSED.value
             elif status_symbol == "✕":

--- a/tests/test_log_parsers_javascript.py
+++ b/tests/test_log_parsers_javascript.py
@@ -1,0 +1,40 @@
+from swebench.harness.log_parsers.javascript import parse_log_jest
+from swebench.harness.constants import TestStatus
+
+
+class TestParseLogJest:
+    """Tests for parse_log_jest used by Jest-based JS/TS repos."""
+
+    def test_parse_pass_and_fail(self):
+        """Test parsing normal verbose Jest output."""
+        log = """✓ adds two numbers (2 ms)
+✕ subtracts two numbers
+○ skipped test
+"""
+        result = parse_log_jest(log, test_spec=None)
+
+        assert len(result) == 3
+        assert result["adds two numbers"] == TestStatus.PASSED.value
+        assert result["subtracts two numbers"] == TestStatus.FAILED.value
+        assert result["skipped test"] == TestStatus.SKIPPED.value
+
+    def test_same_test_name_stable_with_and_without_duration(self):
+        """Jest only prints a "(N ms)" duration suffix above a small timing threshold,
+        so the same test can appear with or without it across runs. The captured test
+        name must be identical either way, otherwise it silently maps to two different
+        dict keys and a real fail->pass transition can be missed."""
+        with_duration = "✓ builds the correct query (105 ms)"
+        without_duration = "✓ builds the correct query"
+
+        result_with = parse_log_jest(with_duration, test_spec=None)
+        result_without = parse_log_jest(without_duration, test_spec=None)
+
+        assert list(result_with.keys()) == ["builds the correct query"]
+        assert list(result_with.keys()) == list(result_without.keys())
+
+    def test_strips_leading_and_trailing_whitespace(self):
+        """Indentation from nested describe blocks shouldn't leak into the test name."""
+        log = "    ✓ works when nested (3 ms)"
+        result = parse_log_jest(log, test_spec=None)
+
+        assert result == {"works when nested": TestStatus.PASSED.value}


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

`parse_log_jest`'s duration suffix group is optional, Jest only prints `(N ms)` above a small timing threshold and combined with the non-greedy test-name capture, this can leave a trailing space in the captured name depending on whether that suffix happened to be present. The same test can then map to two different dict keys across runs, which can hide a real fail-to-pass transition instead of surfacing it.