### PR TITLE
fix(grading): tolerate truncated parametrized test ids from SWE-bench_Verified (#290)

### DIFF
--- a/swebench/harness/grading.py
+++ b/swebench/harness/grading.py
@@ -24,12 +24,39 @@ from swebench.harness.log_parsers import MAP_REPO_TO_PARSER
 
 
 # MARK: Utility functions
+def _resolve_case(case: str, sm: dict[str, str]) -> str | None:
+    """Return the status-map key for ``case``, tolerating truncated parametrized ids.
+
+    662 parametrized test ids in SWE-bench_Verified are truncated mid-parameter
+    (issue #290), e.g. ``test_ogip_grammar_fail[log(photon`` — recognizable by
+    unbalanced square brackets. Such an id can never match the full id pytest
+    reports, so grading counted these cases as missing (i.e. failed) even when
+    they passed. For truncated ids only, fall back to prefix matching: accept a
+    unique prefix match, or multiple matches that all carry the same status
+    (grading is unambiguous either way). Exact ids keep exact-match semantics.
+    """
+    if case in sm:
+        return case
+    if case.count("[") != case.count("]"):
+        matches = [k for k in sm if k.startswith(case)]
+        if matches and (
+            len(matches) == 1 or len({sm[k] for k in matches}) == 1
+        ):
+            return matches[0]
+    return None
+
+
 def test_passed(case: str, sm: dict[str, str]) -> bool:
-    return case in sm and sm[case] in [TestStatus.PASSED.value, TestStatus.XFAIL.value]
+    key = _resolve_case(case, sm)
+    return key is not None and sm[key] in [
+        TestStatus.PASSED.value,
+        TestStatus.XFAIL.value,
+    ]
 
 
 def test_failed(case: str, sm: dict[str, str]) -> bool:
-    return case not in sm or sm[case] in [
+    key = _resolve_case(case, sm)
+    return key is None or sm[key] in [
         TestStatus.FAILED.value,
         TestStatus.ERROR.value,
     ]

--- a/tests/test_grading_truncated_ids.py
+++ b/tests/test_grading_truncated_ids.py
@@ -1,0 +1,70 @@
+"""Regression tests for issue #290: truncated parametrized test ids.
+
+SWE-bench_Verified contains 662 parametrized ids truncated mid-parameter
+(unbalanced brackets). Grading must tolerate them via unambiguous prefix
+matching while preserving exact-match semantics for well-formed ids.
+"""
+
+from swebench.harness.constants import TestStatus
+from swebench.harness.grading import test_failed as grade_failed
+from swebench.harness.grading import test_passed as grade_passed
+
+PASSED = TestStatus.PASSED.value
+FAILED = TestStatus.FAILED.value
+
+
+def test_exact_match_still_exact():
+    sm = {"tests/test_a.py::test_x[case-1]": PASSED}
+    assert grade_passed("tests/test_a.py::test_x[case-1]", sm)
+    assert not grade_failed("tests/test_a.py::test_x[case-1]", sm)
+
+
+def test_missing_balanced_id_is_failed_no_fallback():
+    """A well-formed id absent from the status map must NOT prefix-match."""
+    sm = {"tests/test_a.py::test_x[case-1-extended]": PASSED}
+    assert not grade_passed("tests/test_a.py::test_x[case-1]", sm)
+    assert grade_failed("tests/test_a.py::test_x[case-1]", sm)
+
+
+def test_truncated_id_unique_prefix_match():
+    """The #290 shape: id cut mid-parameter, one matching full id."""
+    truncated = "astropy/units/tests/test_format.py::test_ogip_grammar_fail[log(photon"
+    full = truncated + " / m**2 s)]"
+    sm = {full: PASSED}
+    assert grade_passed(truncated, sm)
+    assert not grade_failed(truncated, sm)
+
+
+def test_truncated_id_no_match_is_failed():
+    sm = {"tests/test_b.py::test_y[other]": PASSED}
+    assert not grade_passed("tests/test_a.py::test_x[log(photon", sm)
+    assert grade_failed("tests/test_a.py::test_x[log(photon", sm)
+
+
+def test_truncated_id_ambiguous_same_status_ok():
+    """Multiple prefix matches with identical status grade unambiguously."""
+    truncated = "tests/test_a.py::test_x[args1-No"
+    sm = {
+        "tests/test_a.py::test_x[args1-None]": PASSED,
+        "tests/test_a.py::test_x[args1-No-value]": PASSED,
+    }
+    assert grade_passed(truncated, sm)
+    assert not grade_failed(truncated, sm)
+
+
+def test_truncated_id_ambiguous_mixed_status_conservative():
+    """Prefix matches with conflicting statuses stay unresolved (failed)."""
+    truncated = "tests/test_a.py::test_x[args1-No"
+    sm = {
+        "tests/test_a.py::test_x[args1-None]": PASSED,
+        "tests/test_a.py::test_x[args1-No-value]": FAILED,
+    }
+    assert not grade_passed(truncated, sm)
+    assert grade_failed(truncated, sm)
+
+
+def test_truncated_failed_id_reports_failed():
+    truncated = "tests/test_a.py::test_x[log(photon"
+    sm = {"tests/test_a.py::test_x[log(photon / m**2 s)]": FAILED}
+    assert not grade_passed(truncated, sm)
+    assert grade_failed(truncated, sm)


### PR DESCRIPTION
## Why

Fixes #290. SWE-bench_Verified contains **662 parametrized test ids truncated mid-parameter** (`grep "::.*\[[^]]*$"`), e.g.:

```
astropy/units/tests/test_format.py::test_ogip_grammar_fail[log(photon
lib/matplotlib/tests/test_axes.py::test_margins_errors[TypeError-args6-kwargs6-Must
```

A truncated id can never equal the full id pytest reports, so `test_passed`/`test_failed` in `swebench/harness/grading.py` count these cases as *missing → failed even when they passed* — silently deflating scores on affected instances (and contributing to "gold patch does not resolve" reports). Since the dataset is published and mirrored, harness-side tolerance is the practical fix.

## What

`_resolve_case()` in `grading.py`: when an id is **not** an exact key and shows the truncation signature (**unbalanced square brackets** — impossible for a well-formed pytest id), fall back to prefix matching against the status map. The fallback only resolves when grading is unambiguous:

- exactly one prefix match, **or**
- multiple matches that all carry the same status.

Ambiguous conflicts stay unresolved (= failed), preserving conservative grading. Well-formed ids keep pure exact-match semantics — behavior is unchanged for every non-truncated id.

## Tests

`tests/test_grading_truncated_ids.py` — 7 cases: exact ids still exact; balanced-but-missing ids do **not** prefix-match; the #290 shape resolves (passed and failed variants); no-match stays failed; ambiguous same-status resolves; ambiguous mixed-status stays failed.

```
tests/test_grading_truncated_ids.py: 7 passed
tests/test_harness_utils.py, tests/test_evaluation.py: 6 passed (unchanged)
```

Provenance: I maintain an SWE-bench-compatible evaluation harness and hit these ids in practice; this mirrors the prefix-match tolerance we ship there.
