### PR TITLE
fix(harness): reset new test files in the common eval-script builder (follow-up to #539)

### DIFF
--- a/swebench/harness/test_spec/javascript.py
+++ b/swebench/harness/test_spec/javascript.py
@@ -94,8 +94,15 @@ def make_eval_script_list_js(
     eval_commands = make_eval_script_list_common(
         instance, specs, env_name, repo_directory, base_commit, test_patch
     )
-    # Insert downloading right after reset command
-    eval_commands[4:4] = get_download_img_commands(instance)
+    # Insert image downloads right before the official test patch is applied, i.e.
+    # after all pre-test reset commands. Anchor on the apply command rather than a
+    # fixed index: the common builder can now emit more than one reset command
+    # (git checkout for modified files + rm -f for new files), so a hard-coded
+    # eval_commands[4:4] would land between the two resets.
+    apply_idx = next(
+        i for i, cmd in enumerate(eval_commands) if cmd.startswith("git apply")
+    )
+    eval_commands[apply_idx:apply_idx] = get_download_img_commands(instance)
     if instance["repo"] in MAP_REPO_TO_TEST_CMDS:
         # Update test commands if they are custom commands
         test_commands = MAP_REPO_TO_TEST_CMDS[instance["repo"]](instance)

--- a/swebench/harness/test_spec/utils.py
+++ b/swebench/harness/test_spec/utils.py
@@ -3,7 +3,7 @@ from swebench.harness.constants import (
     MAP_REPO_VERSION_TO_SPECS,
     START_TEST_OUTPUT,
 )
-from swebench.harness.utils import get_modified_files
+from swebench.harness.utils import get_modified_files, get_new_files
 
 
 # MARK: Test Command Creation Functions
@@ -63,12 +63,22 @@ def make_eval_script_list_common(
     Applies the test patch and runs the tests.
     """
     HEREDOC_DELIMITER = "EOF_114329324912"
-    test_files = get_modified_files(test_patch)
-    # Reset test files to the state they should be in before the patch.
-    if test_files:
-        reset_tests_command = f"git checkout {base_commit} {' '.join(test_files)}"
-    else:
-        reset_tests_command = 'echo "No test files to reset"'
+    # Reset test files to the state they should be in before the patch. Modified
+    # files (present at base_commit) are restored with `git checkout`; new files
+    # (source /dev/null) are not at base_commit, so they must be removed with
+    # `rm -f` instead. This mirrors the fix applied to the Python builder in #539:
+    # get_modified_files() skips /dev/null-source files, so a new-file-only test
+    # patch would otherwise produce no reset command here and let a submitted
+    # patch's file at a gold-added test path survive grading (#538).
+    modified_files = get_modified_files(test_patch)
+    new_files = get_new_files(test_patch)
+    reset_commands = []
+    if modified_files:
+        reset_commands.append(f"git checkout {base_commit} {' '.join(modified_files)}")
+    if new_files:
+        reset_commands.append(f"rm -f {' '.join(new_files)}")
+    if not reset_commands:
+        reset_commands = ['echo "No test files to reset"']
 
     build_commands = []
     if "build" in specs:
@@ -84,12 +94,12 @@ def make_eval_script_list_common(
         # f"git status",
         # f"git show",
         # f"git -c core.fileMode=false diff {base_commit}",
-        reset_tests_command,
+        *reset_commands,
         apply_test_patch_command,
         *build_commands,
         f": '{START_TEST_OUTPUT}'",
         *test_commands,
         f": '{END_TEST_OUTPUT}'",
-        reset_tests_command,
+        *reset_commands,  # Revert tests after done, leave the repo as before.
     ]
     return eval_commands

--- a/tests/test_eval_script_reset.py
+++ b/tests/test_eval_script_reset.py
@@ -1,0 +1,127 @@
+"""Regression tests for pre/post-test reset in the common eval-script builder.
+
+#539 fixed new-file-only test patches for the Python builder (test_spec/python.py)
+by removing new files with `rm -f` instead of a bare `git checkout {base_commit}`.
+The common builder (test_spec/utils.make_eval_script_list_common), used by the
+JavaScript / Go / Java / etc. builders, still only reset via get_modified_files(),
+so a new-file-only test patch produced no reset for the new files — letting a
+submitted patch's file at a gold-added test path survive grading (#538). These
+tests pin the ported behaviour and the ordering it must preserve.
+"""
+
+import json
+import unittest
+from unittest.mock import patch
+
+from swebench.harness.test_spec import javascript as js_builder
+from swebench.harness.test_spec.utils import make_eval_script_list_common
+from swebench.harness.utils import get_modified_files, get_new_files
+
+_NEW_ONLY = (
+    "diff --git a/tests/test_new.py b/tests/test_new.py\n"
+    "new file mode 100644\n"
+    "--- /dev/null\n"
+    "+++ b/tests/test_new.py\n"
+    "@@ -0,0 +1,1 @@\n"
+    "+def test_x():\n"
+)
+_MODIFIED_ONLY = (
+    "diff --git a/tests/test_mod.py b/tests/test_mod.py\n"
+    "--- a/tests/test_mod.py\n"
+    "+++ b/tests/test_mod.py\n"
+    "@@ -1,1 +1,2 @@\n"
+    " a\n"
+    "+b\n"
+)
+_MIXED = _MODIFIED_ONLY + _NEW_ONLY
+
+_BASE = "BASECOMMIT"
+
+
+def _common_cmds(test_patch):
+    # get_test_cmds() reads the global MAP_REPO_VERSION_TO_SPECS; stub it so the
+    # test exercises the reset/apply ordering without a real repo+version entry.
+    with patch(
+        "swebench.harness.test_spec.utils.get_test_cmds", return_value=["run-tests"]
+    ):
+        return make_eval_script_list_common(
+            {"repo": "o/r", "version": "1"}, {}, "env", "/testbed", _BASE, test_patch
+        )
+
+
+def _apply_idx(cmds):
+    return next(i for i, c in enumerate(cmds) if c.startswith("git apply"))
+
+
+def _checkout_cmd(patch_text):
+    return f"git checkout {_BASE} {' '.join(get_modified_files(patch_text))}"
+
+
+def _rm_cmd(patch_text):
+    return f"rm -f {' '.join(get_new_files(patch_text))}"
+
+
+class CommonResetTests(unittest.TestCase):
+    def test_new_only_is_removed_not_checked_out(self):
+        cmds = _common_cmds(_NEW_ONLY)
+        rm = _rm_cmd(_NEW_ONLY)
+        pre = cmds[: _apply_idx(cmds)]
+        self.assertIn(rm, pre, "new file must be rm -f'd before the official apply")
+        self.assertFalse(
+            any(c.startswith(f"git checkout {_BASE}") for c in cmds),
+            "new-file-only patch must not emit a bare `git checkout {base}` reset",
+        )
+        self.assertFalse(
+            any("No test files to reset" in c for c in cmds),
+            "new-file-only patch must reset (rm) the new file, not no-op",
+        )
+        # Reset runs before apply AND again after the test-output block.
+        self.assertEqual(cmds.count(rm), 2)
+
+    def test_mixed_checkout_then_rm_before_apply(self):
+        cmds = _common_cmds(_MIXED)
+        co, rm, ai = _checkout_cmd(_MIXED), _rm_cmd(_MIXED), _apply_idx(cmds)
+        pre = cmds[:ai]
+        self.assertIn(co, pre)
+        self.assertIn(rm, pre)
+        self.assertLess(
+            pre.index(co), pre.index(rm), "modified checkout must precede new-file rm"
+        )
+        self.assertLess(pre.index(rm), ai, "all resets must precede the official apply")
+        self.assertEqual(cmds.count(co), 2)
+        self.assertEqual(cmds.count(rm), 2)
+
+    def test_modified_only_behaviour_unchanged(self):
+        cmds = _common_cmds(_MODIFIED_ONLY)
+        co = _checkout_cmd(_MODIFIED_ONLY)
+        self.assertEqual(cmds.count(co), 2)
+        self.assertFalse(any(c.startswith("rm -f") for c in cmds))
+
+
+class JsDownloadOrderingTests(unittest.TestCase):
+    def test_downloads_after_all_resets_before_apply(self):
+        instance = {
+            "repo": "o/r",
+            "version": "1",
+            "test_patch": _MIXED,
+            "image_assets": json.dumps(
+                {"test_patch": [{"path": "assets/img.png", "url": "http://x/img.png"}]}
+            ),
+        }
+        with patch(
+            "swebench.harness.test_spec.utils.get_test_cmds", return_value=["run-tests"]
+        ):
+            cmds = js_builder.make_eval_script_list_js(
+                instance, {}, "env", "/testbed", _BASE, _MIXED
+            )
+        ai = _apply_idx(cmds)
+        co_idx = cmds.index(_checkout_cmd(_MIXED))
+        rm_idx = cmds.index(_rm_cmd(_MIXED))
+        dl_idx = next(i for i, c in enumerate(cmds) if c.startswith("curl -o"))
+        self.assertLess(co_idx, rm_idx, "resets stay ordered")
+        self.assertLess(rm_idx, dl_idx, "downloads come after all pre-test resets")
+        self.assertLess(dl_idx, ai, "downloads come before the official apply")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Follow-up to #539 / #538.

#539 fixed new-file-only test patches for the **Python** builder (`test_spec/python.py`) by removing new files with `rm -f` instead of a bare `git checkout {base_commit}`. That fix was not applied to `make_eval_script_list_common` (`test_spec/utils.py`), which is the builder used by the **JavaScript / Go / Java / etc.** paths via `make_test_spec`.

`make_eval_script_list_common` still computes its reset from `get_modified_files()` only, which skips `/dev/null`-source (new) files. For a **new-file-only** test patch this yields `echo "No test files to reset"` and never removes the file. As a result, a submitted patch that adds a file at a **gold-added test path** survives grading: the official `test_patch` fails to apply the new file (`already exists in working directory`) while the submitted (poisoned) test runs and can flip the instance to `resolved` — the same #538 manipulation, on the non-Python path.

This is not theoretical for the common path: for example `babel__babel-16130` (JavaScript, single `FAIL_TO_PASS` entirely defined by a gold-added Jest fixture directory) is gradeable as resolved with a planted passing fixture and no real fix under the current common builder.

## Changes

- `test_spec/utils.py` (`make_eval_script_list_common`): separate modified vs new files, reset modified with `git checkout {base_commit} …` and new with `rm -f …`, both before the official apply and again after the test-output block. Handles new-only and mixed modified+new; falls back to the existing no-op string only when the test patch touches no files. Mirrors the #539 python.py fix.
- `test_spec/javascript.py` (`make_eval_script_list_js`): insert the image-download commands by anchoring on the `git apply` command rather than the fixed `eval_commands[4:4]` index. With the common reset now possibly emitting two commands (`git checkout` + `rm -f`), the fixed index would insert the downloads *between* the two resets.

Scope is intentionally narrow: this is the #539 parity fix for the common builder. It does not refactor the Python builder, does not touch the marker/exit-code grading path (that is a separate concern, cf. #601/#608), and does not rework shell path-safety.

## Tests

`tests/test_eval_script_reset.py` (all executed, pass):
- new-only: `rm -f` appears before the official apply and again after the test block; no bare `git checkout {base}`; no `No test files to reset`.
- mixed: `git checkout` precedes `rm -f`, and both precede the apply; each repeated after the test block.
- modified-only: behaviour unchanged (checkout only, no `rm -f`).
- JavaScript image-assets: download commands land after all pre-test resets and before the official apply, without depending on a fixed array index.

Actual local test scope run: `pytest tests/test_eval_script_reset.py tests/test_harness_utils.py` (9 passed) + `ruff check` / `ruff format --check` on the changed files (clean). I did not run the full harness/end-to-end suite (it requires Docker images and dataset access); the changes are covered by the executable structural regressions above.