### PR TITLE
[codex] Preserve API usage details in inference outputs

### DIFF
--- a/swebench/inference/run_api.py
+++ b/swebench/inference/run_api.py
@@ -22,6 +22,7 @@ from tenacity import (
 )
 from datasets import load_dataset, load_from_disk
 from swebench.inference.make_datasets.utils import extract_diff
+from swebench.inference.usage import usage_to_dict
 from argparse import ArgumentParser
 import logging
 
@@ -234,6 +235,11 @@ def openai_inference(
             completion = response.choices[0].message.content
             total_cost += cost
             print(f"Total Cost: {total_cost:.2f}")
+            output_dict["usage"] = usage_to_dict(
+                response.usage,
+                input_tokens_field="prompt_tokens",
+                output_tokens_field="completion_tokens",
+            )
             output_dict["full_output"] = completion
             output_dict["model_patch"] = extract_diff(completion)
             print(json.dumps(output_dict), file=f, flush=True)
@@ -396,6 +402,11 @@ def anthropic_inference(
                 output_dict["full_output"] = completion.content[0].text
             else:
                 output_dict["full_output"] = completion.completion
+            output_dict["usage"] = usage_to_dict(
+                getattr(completion, "usage", None),
+                input_tokens_field="input_tokens",
+                output_tokens_field="output_tokens",
+            )
             output_dict["model_patch"] = extract_diff(output_dict["full_output"])
             print(json.dumps(output_dict), file=f, flush=True)
             if max_cost is not None and total_cost >= max_cost:

--- a/swebench/inference/usage.py
+++ b/swebench/inference/usage.py
@@ -1,0 +1,53 @@
+"""Helpers for preserving provider token usage details in inference outputs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _usage_value(obj: Any, key: str, default: Any = None) -> Any:
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def usage_to_dict(
+    usage: Any,
+    *,
+    input_tokens_field: str,
+    output_tokens_field: str,
+) -> dict[str, Any]:
+    """Normalize SDK usage objects into JSON-serializable token counters."""
+    if usage is None:
+        return {}
+
+    result = {}
+
+    input_tokens = _usage_value(usage, input_tokens_field)
+    output_tokens = _usage_value(usage, output_tokens_field)
+    if input_tokens is not None:
+        result["input_tokens"] = input_tokens
+    if output_tokens is not None:
+        result["output_tokens"] = output_tokens
+
+    token_details = (
+        _usage_value(usage, "prompt_tokens_details")
+        or _usage_value(usage, "input_tokens_details")
+    )
+    cached_input_tokens = _usage_value(token_details, "cached_tokens")
+    cache_creation_input_tokens = _usage_value(usage, "cache_creation_input_tokens")
+    cache_read_input_tokens = _usage_value(usage, "cache_read_input_tokens")
+
+    if cache_read_input_tokens is not None and cached_input_tokens is None:
+        cached_input_tokens = cache_read_input_tokens
+
+    if cached_input_tokens is not None:
+        result["cached_input_tokens"] = cached_input_tokens
+    if cache_creation_input_tokens is not None:
+        result["cache_creation_input_tokens"] = cache_creation_input_tokens
+    if cache_read_input_tokens is not None:
+        result["cache_read_input_tokens"] = cache_read_input_tokens
+
+    return result

--- a/tests/test_inference_usage.py
+++ b/tests/test_inference_usage.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+
+from swebench.inference.usage import usage_to_dict
+
+
+def test_usage_to_dict_preserves_openai_cached_tokens():
+    usage = SimpleNamespace(
+        prompt_tokens=100,
+        completion_tokens=20,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=40),
+    )
+
+    assert usage_to_dict(
+        usage,
+        input_tokens_field="prompt_tokens",
+        output_tokens_field="completion_tokens",
+    ) == {
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "cached_input_tokens": 40,
+    }
+
+
+def test_usage_to_dict_preserves_anthropic_cache_tokens():
+    usage = SimpleNamespace(
+        input_tokens=100,
+        output_tokens=20,
+        cache_creation_input_tokens=15,
+        cache_read_input_tokens=35,
+    )
+
+    assert usage_to_dict(
+        usage,
+        input_tokens_field="input_tokens",
+        output_tokens_field="output_tokens",
+    ) == {
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "cached_input_tokens": 35,
+        "cache_creation_input_tokens": 15,
+        "cache_read_input_tokens": 35,
+    }
+
+
+def test_usage_to_dict_handles_dict_details():
+    usage = {
+        "prompt_tokens": 100,
+        "completion_tokens": 20,
+        "prompt_tokens_details": {"cached_tokens": 40},
+    }
+
+    assert usage_to_dict(
+        usage,
+        input_tokens_field="prompt_tokens",
+        output_tokens_field="completion_tokens",
+    ) == {
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "cached_input_tokens": 40,
+    }


### PR DESCRIPTION
Summary
- add a stdlib-only helper for serializing provider usage counters
- include usage counters in run_api.py JSONL outputs for OpenAI and Anthropic responses
- preserve OpenAI cached-token and Anthropic cache read/write counters when providers return them

Why
- API inference currently writes model outputs but drops provider cache-token details, which makes downstream cost and cache analysis harder.
- This keeps the existing request behavior and cost calculation unchanged; it only records the counters that are already returned by SDKs.

Validation
- .venv/bin/python -m pytest tests/test_inference_usage.py -q
- .venv/bin/python -m compileall -q swebench/inference/usage.py swebench/inference/run_api.py
- git diff --check