### PR TITLE
Fix three harness bugs that silently drop instances

### DIFF
--- a/swebench/cli/images.py
+++ b/swebench/cli/images.py
@@ -28,7 +28,7 @@ def build(
     workers: int = typer.Option(4, "-j", "--workers"),
     force_rebuild: bool = typer.Option(False, "--force-rebuild"),
     namespace: Optional[str] = typer.Option(None, "-n", "--namespace", help="Registry namespace to tag for"),
-    tag: Optional[str] = typer.Option(None, "--tag"),
+    tag: str = typer.Option("latest", "--tag"),
     dockerfile_repo: Optional[str] = typer.Option(None, "--dockerfile-repo", help="Path or GitHub ref"),
     dry_run: bool = typer.Option(False, "--dry-run", help="List what would be built"),
     open_file_limit: int = typer.Option(4096, "--open-file-limit"),

--- a/swebench/harness/docker_utils.py
+++ b/swebench/harness/docker_utils.py
@@ -142,4 +142,5 @@ def exec_run_with_timeout(container, cmd, timeout: int | None = 60):
             container.exec_run(f"kill -TERM {exec_pid}", detach=True)
         timed_out = True
     end_time = time.time()
-    return exec_result.decode(), timed_out, end_time - start_time
+    # test output is arbitrary bytes; a stray non-UTF-8 byte must not kill the run
+    return exec_result.decode(errors="replace"), timed_out, end_time - start_time

--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -12,7 +12,11 @@ if platform.system() == "Linux":
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 from pathlib import Path, PurePosixPath
 
-from swebench.image_builder.constants import CONTAINER_USER, CONTAINER_WORKDIR
+from swebench.image_builder.constants import (
+    CONTAINER_SECURITY_OPT,
+    CONTAINER_USER,
+    CONTAINER_WORKDIR,
+)
 from swebench.harness.constants import (
     APPLY_PATCH_FAIL,
     APPLY_PATCH_PASS,
@@ -114,6 +118,7 @@ def create_container(
                 user=CONTAINER_USER,
                 detach=True,
                 command="tail -f /dev/null",
+                security_opt=CONTAINER_SECURITY_OPT,
             )
         except docker.errors.APIError as e:
             if "409" in str(e) or "Conflict" in str(e):

--- a/swebench/image_builder/constants/__init__.py
+++ b/swebench/image_builder/constants/__init__.py
@@ -5,6 +5,8 @@ IMAGE_BUILDER_LOG_DIR = Path("logs/image_builder")
 # Constants - Docker Image Building
 CONTAINER_USER = "root"
 CONTAINER_WORKDIR = "/testbed"
+# Docker's default seccomp profile blocks CLONE_NEWUSER, which browser sandboxes need
+CONTAINER_SECURITY_OPT = ["seccomp=unconfined"]
 CONTAINER_ENV_NAME = "testbed"
 
 # Constants - Installation Logging


### PR DESCRIPTION
Three independent bugs found while running a full gold evaluation of
SWE-bench Multimodal from a cold start (every image pulled, no local cache).
Each one is small, and each one silently costs you instances.

### 1. Eval containers cannot start a browser sandbox on current Docker

Docker Engine 29's default seccomp profile blocks `CLONE_NEWUSER`, which Chrome's
sandbox needs. Reproduced in a single idle container:

```
Failed to move to new namespace: PID namespaces supported,
Network namespace supported, but failed: errno = Operation not permitted
FATAL:zygote_host_impl_linux.cc(201) Check failed: Operation not permitted
```

v4 passed each spec's `docker_specs.run_args` (notably `cap_add: [SYS_ADMIN]`)
into container creation. The v5 dataset schema has no `run_args` column and
`create_container` passes no security options, so that relaxation is silently
dropped. `--cap-add=SYS_ADMIN` alone does not fix it; `seccomp=unconfined` does.

Effect on alibaba-fusion instances: **2 passed / 9 failed -> 17 passed / 0 failed**.

### 2. One stray byte in test output discards the whole instance

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2 in position 409775
  docker_utils.py:145  exec_result.decode()
```

The instance produces no report at all. This killed 4 instances in one run.
Decoding arbitrary test output should never be able to abort an evaluation.

### 3. `swebench images build` always crashes

`--tag` defaulted to `None`, which trips `assert tag is not None` in
`make_image_spec`, so the command is unusable as shipped.

### Result

495 / 496 multimodal instances resolved on a cold pull-mode run with these
applied. The remaining one is unrelated to the harness.
