### PR TITLE
Revert seccomp relaxation from #635; it regressed openlayers

### DIFF
--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -12,11 +12,7 @@ if platform.system() == "Linux":
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 from pathlib import Path, PurePosixPath
 
-from swebench.image_builder.constants import (
-    CONTAINER_SECURITY_OPT,
-    CONTAINER_USER,
-    CONTAINER_WORKDIR,
-)
+from swebench.image_builder.constants import CONTAINER_USER, CONTAINER_WORKDIR
 from swebench.harness.constants import (
     APPLY_PATCH_FAIL,
     APPLY_PATCH_PASS,
@@ -118,7 +114,6 @@ def create_container(
                 user=CONTAINER_USER,
                 detach=True,
                 command="tail -f /dev/null",
-                security_opt=CONTAINER_SECURITY_OPT,
             )
         except docker.errors.APIError as e:
             if "409" in str(e) or "Conflict" in str(e):

--- a/swebench/image_builder/constants/__init__.py
+++ b/swebench/image_builder/constants/__init__.py
@@ -5,8 +5,6 @@ IMAGE_BUILDER_LOG_DIR = Path("logs/image_builder")
 # Constants - Docker Image Building
 CONTAINER_USER = "root"
 CONTAINER_WORKDIR = "/testbed"
-# Docker's default seccomp profile blocks CLONE_NEWUSER, which browser sandboxes need
-CONTAINER_SECURITY_OPT = ["seccomp=unconfined"]
 CONTAINER_ENV_NAME = "testbed"
 
 # Constants - Installation Logging


### PR DESCRIPTION
Follow-up to #635, which I got wrong.

#635 set `seccomp=unconfined` on eval containers so Chrome's namespace sandbox
could start. That fixed alibaba-fusion (2/11 -> 17/17 passing) but **broke 12
openlayers instances**, which had been passing.

Evidence:

| config | alibaba-fusion | openlayers |
|---|---|---|
| default seccomp | 2/11 pass | passes |
| `seccomp=unconfined` (#635) | 17/17 pass | 12 fail |
| default seccomp + `TRAVIS=1` | 17/17 pass | passes |

Confirmed two ways: every affected openlayers instance passed before #635 went
live and failed after, and reverting the setting for `openlayers-12393` /
`openlayers-13013` makes them pass again immediately.

Mechanism: under Docker's default seccomp, Chrome cannot create a user namespace
and degrades to running unsandboxed, where software WebGL under Xvfb works. With
seccomp unconfined the sandbox initialises, SwiftShader runs differently, and
openlayers' WebGL rendering comparisons fail. openlayers is the only repo doing
those comparisons, so it is the only one that notices.

This reverts the container-level relaxation. The targeted fix belongs in the
instances that need it: alibaba-fusion's own `scripts/test/karma.js` already
defines a `--no-sandbox` launcher gated on `process.env.TRAVIS`, so setting
`TRAVIS=1` for those instances fixes them with no privilege change at all
(verified: 0 Chrome launch failures, 31/31 tests pass under default seccomp).
That part is a dataset `eval_script` change and will follow separately.
