### PR TITLE
Add swebench publish: upload run results to an HF bucket + eval-results yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Other commands:
 swebench images build verified -j 8           # build/pull images ahead of time
 swebench images check multilingual            # verify images exist on the registry
 swebench images clean --run-id <run_id>       # remove leftover containers
+swebench publish <run_id> -b <user/bucket> --report <report.json> -d verified --task-id swe_bench_%_resolved   # upload results to an HF bucket
 swebench --help                               # all commands
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,6 +43,16 @@ swebench report my-run                     # dataset taken from the run itself
 swebench report my-run -d multimodal -i grommet__grommet-6282
 ```
 
+### `swebench publish RUN_ID`
+
+Upload a run's report (and predictions) to a Hugging Face bucket, and write a
+`.eval_results/*.yaml` entry scored against it
+([format](https://huggingface.co/docs/hub/eval-results)).
+
+```bash
+swebench publish my-run -b myuser/swebench-runs --report gpt5.my-run.json -d verified --task-id swe_bench_%_resolved
+```
+
 ## Images
 
 Images are built from a task repo: each task carries its own Dockerfile, and its

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "docker",
     "ghapi<2",  # 2.x is async: every call returns a coroutine
     "GitPython",
+    "huggingface_hub>=1.20",
     "modal",
     "pre-commit",
     "python-dotenv",

--- a/swebench/cli/cli.py
+++ b/swebench/cli/cli.py
@@ -18,6 +18,7 @@ app = typer.Typer(
     swebench eval verified -p preds.jsonl --run-id gpt5 -j 16
     swebench eval multimodal --gold -i carbon-design-system__carbon-10188
     swebench report my-run -d verified
+    swebench publish gpt5 -b myuser/swebench-runs -p preds.jsonl --model-id openai/gpt-5
     swebench images build verified -j 8
     swebench images check multilingual
     swebench images clean --run-id my-run
@@ -45,10 +46,15 @@ def main():
 
 
 from swebench.cli.dataset import dataset_app  # noqa: E402
-from swebench.cli.evaluate import eval_command, report_command  # noqa: E402
+from swebench.cli.evaluate import (  # noqa: E402
+    eval_command,
+    publish_command,
+    report_command,
+)
 from swebench.cli.images import images_app  # noqa: E402
 
 app.command("eval", rich_help_panel=_PANEL_EVAL)(eval_command)
 app.command("report", rich_help_panel=_PANEL_EVAL)(report_command)
+app.command("publish", rich_help_panel=_PANEL_EVAL)(publish_command)
 app.add_typer(images_app, name="images", rich_help_panel=_PANEL_IMAGES)
 app.add_typer(dataset_app, name="dataset", rich_help_panel=_PANEL_DATA)

--- a/swebench/cli/evaluate.py
+++ b/swebench/cli/evaluate.py
@@ -1,5 +1,7 @@
-"""`swebench eval` and `swebench report`."""
+"""`swebench eval`, `swebench report`, and `swebench publish`."""
 
+import json
+from pathlib import Path
 from typing import Optional
 
 import typer
@@ -134,3 +136,30 @@ def report_command(
         # or the dataset's copy silently overrides them and the verdict changes
         task_repo=recorded.get("task_repo"),
     )
+
+
+def publish_command(
+    run_id: str = typer.Argument(...),
+    bucket: str = typer.Option(..., "-b", "--bucket"),
+    report: str = typer.Option(..., "--report"),
+    dataset: str = typer.Option(..., "-d", "--dataset"),
+    task_id: str = typer.Option(..., "--task-id"),
+    predictions: Optional[str] = typer.Option(None, "-p", "--predictions"),
+    out: str = typer.Option(".eval_results/result.yaml", "--out"),
+    dry_run: bool = typer.Option(False, "--dry-run"),
+):
+    from swebench.harness.publish_results import upload_run, write_eval_result
+
+    files = [report] + ([predictions] if predictions else [])
+    plan = upload_run(bucket, run_id, files, dry_run=dry_run)
+    typer.echo(json.dumps(plan, indent=2))
+    if dry_run:
+        return
+
+    report_data = json.loads(Path(report).read_text())
+    value = 100 * report_data["resolved_instances"] / report_data["total_instances"]
+    source_url = f"https://huggingface.co/buckets/{bucket}/resolve/{plan['files'][0]}"
+    out_path = write_eval_result(
+        resolve_dataset(dataset), task_id, value, source_url, out
+    )
+    typer.echo(f"wrote {out_path}")

--- a/swebench/harness/publish_results.py
+++ b/swebench/harness/publish_results.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import yaml
+
+
+def upload_run(bucket_id, run_id, files, private=True, dry_run=False):
+    files = [Path(f) for f in files]
+    plan = {"bucket": bucket_id, "files": [f"{run_id}/{f.name}" for f in files]}
+    if dry_run:
+        return plan
+
+    from huggingface_hub import HfApi
+
+    api = HfApi()
+    api.create_bucket(bucket_id, private=private, exist_ok=True)
+    api.batch_bucket_files(bucket_id, add=list(zip(files, plan["files"])))
+    return plan
+
+
+def write_eval_result(dataset, task_id, value, source_url, out_path):
+    entry = {
+        "dataset": {"id": dataset, "task_id": task_id},
+        "value": value,
+        "source": {"url": source_url},
+    }
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(yaml.safe_dump([entry], sort_keys=False))
+    return out_path

--- a/tests/test_publish_results.py
+++ b/tests/test_publish_results.py
@@ -1,0 +1,30 @@
+import yaml
+
+from swebench.harness.publish_results import upload_run, write_eval_result
+
+
+def test_upload_run_dry_run(tmp_path):
+    f = tmp_path / "report.json"
+    f.write_text("{}")
+    plan = upload_run("me/bucket", "run-1", [f], dry_run=True)
+    assert plan == {"bucket": "me/bucket", "files": ["run-1/report.json"]}
+
+
+def test_write_eval_result(tmp_path):
+    out = write_eval_result(
+        "SWE-bench/SWE-bench_Verified",
+        "swe_bench_%_resolved",
+        42.0,
+        "https://example.com/report.json",
+        tmp_path / "result.yaml",
+    )
+    assert yaml.safe_load(out.read_text()) == [
+        {
+            "dataset": {
+                "id": "SWE-bench/SWE-bench_Verified",
+                "task_id": "swe_bench_%_resolved",
+            },
+            "value": 42.0,
+            "source": {"url": "https://example.com/report.json"},
+        }
+    ]


### PR DESCRIPTION
## Summary
- Adds `swebench publish RUN_ID`, which uploads a run's report (and optionally its predictions) to a Hugging Face bucket and writes a `.eval_results/*.yaml` entry scored against it.
- The yaml format matches the Hub's community eval-results system: https://huggingface.co/docs/hub/eval-results
- New module `swebench/harness/publish_results.py`: `upload_run()` (create/upload to a bucket, `dry_run` supported) and `write_eval_result()` (writes one eval-results entry).
- Adds `huggingface_hub>=1.20` as a dependency (needed for bucket support).

## Test plan
- [x] `pytest tests/test_publish_results.py` passes
- [x] `swebench publish --help` and a `--dry-run` invocation work end-to-end against a fabricated report file
- [x] `ruff format`/`ruff check` clean relative to the existing codebase conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)