### PR TITLE
Forward proxy environment variables into evaluation containers

### DIFF
--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -61,6 +61,29 @@ GIT_APPLY_CMDS = [
 DOCKER_CLIENT_TIMEOUT = int(os.environ.get("SWEBENCH_DOCKER_TIMEOUT", "1800"))
 DOCKER_CLIENT_POOL_SIZE = int(os.environ.get("SWEBENCH_DOCKER_POOL_SIZE", "128"))
 
+PROXY_ENV_KEYS = (
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "FTP_PROXY",
+    "ALL_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "ftp_proxy",
+    "all_proxy",
+    "NO_PROXY",
+    "no_proxy",
+)
+
+
+def _proxy_environment() -> dict:
+    """
+    Forward proxy settings from the host process into evaluation containers so
+    network-dependent test suites (e.g. requests, which talks to httpbin.org)
+    can reach the internet through the host's proxy. Returns an empty dict when
+    the host has no proxy variables set.
+    """
+    return {k: v for k, v in os.environ.items() if k in PROXY_ENV_KEYS}
+
 
 def _docker_client() -> docker.DockerClient:
     return docker.from_env(
@@ -119,6 +142,7 @@ def create_container(
                 user=CONTAINER_USER,
                 detach=True,
                 command="tail -f /dev/null",
+                environment=_proxy_environment(),
                 # Docker's default seccomp profile only permits CLONE_NEWUSER with
                 # CAP_SYS_ADMIN, which browser sandboxes need (e.g. openlayers karma)
                 cap_add=["SYS_ADMIN"],
@@ -136,6 +160,7 @@ def create_container(
                     user=CONTAINER_USER,
                     detach=True,
                     command="tail -f /dev/null",
+                    environment=_proxy_environment(),
                     # Docker's default seccomp profile only permits CLONE_NEWUSER with
                     # CAP_SYS_ADMIN, which browser sandboxes need (e.g. openlayers karma)
                     cap_add=["SYS_ADMIN"],


### PR DESCRIPTION
Network-dependent test suites (e.g. the psf__requests-* instances in SWE-bench Lite, which talk to httpbin.org) hang and time out when the host can only reach the internet through a proxy, because evaluation containers are created without the host's proxy environment.

Collect HTTP(S)_PROXY / NO_PROXY (and lowercase variants) from os.environ and pass them via environment=... to both client.containers.create(...) calls in create_container(). When no proxy is set, the helper returns an empty dict and behavior is unchanged.

#### Reference Issues/PRs

Fixes #646

#### What does this implement/fix? Explain your changes.

Evaluation containers are currently created without any proxy environment
variables, so test suites that make outbound HTTP requests (e.g. the
`psf__requests-*` instances in SWE-bench Lite) hang and time out on hosts that
can only reach the internet through a proxy.

This PR forwards the host's proxy settings into each evaluation container:

- Adds `PROXY_ENV_KEYS` and a `_proxy_environment()` helper in
  `swebench/harness/run_evaluation.py` that collects
  `HTTP_PROXY` / `HTTPS_PROXY` / `FTP_PROXY` / `ALL_PROXY` (and their lowercase
  forms) plus `NO_PROXY` / `no_proxy` from `os.environ`.
- Passes `environment=_proxy_environment()` to both
  `client.containers.create(...)` calls in `create_container()`.

When no proxy variables are set on the host, the helper returns an empty dict
and behavior is unchanged. This only affects the environment of the evaluation
container, not image pulls (which the Docker daemon already handles separately).

#### Any other comments?

Verified manually by running `psf__requests-863` behind a proxy: the instance
previously timed out after 1800s; with this change the test suite completes and
the network-dependent tests can reach `httpbin.org`.
