### PR TITLE
fix: write eval.sh and patch.diff with LF on Windows hosts

### DIFF
--- a/swebench/harness/run_evaluation.py
+++ b/swebench/harness/run_evaluation.py
@@ -47,6 +47,7 @@ from swebench.harness.utils import (
     get_predictions_from_file,
     run_threadpool,
     str2bool,
+    write_container_text,
 )
 
 from swebench.logger import setup_logger, close_logger
@@ -288,7 +289,7 @@ def run_instance(
         if not skip_patch:
             # Copy model prediction as patch file to container
             patch_file = Path(log_dir / "patch.diff")
-            patch_file.write_text(pred["model_patch"] or "")
+            write_container_text(patch_file, pred["model_patch"] or "")
             logger.info(
                 f"Intermediate patch for {instance_id} written to {patch_file}, now applying to container..."
             )
@@ -357,7 +358,9 @@ def run_instance(
         )
 
         eval_file = Path(log_dir / "eval.sh")
-        eval_file.write_text(_inject_asset_restore(test_spec.eval_script, restore_cmds))
+        write_container_text(
+            eval_file, _inject_asset_restore(test_spec.eval_script, restore_cmds)
+        )
         logger.info(
             f"Eval script for {instance_id} written to {eval_file}; copying to container..."
         )

--- a/swebench/harness/utils.py
+++ b/swebench/harness/utils.py
@@ -210,6 +210,15 @@ def optional_str(value: str) -> str | None:
     return value
 
 
+def write_container_text(path: Path, text: str) -> None:
+    """Write text with LF endings for files that Linux eval containers will read.
+
+    Path.write_text() uses the platform newline on Windows, so eval.sh / patch.diff
+    become CRLF and bash / git apply fail inside the container (silent 0% resolve).
+    """
+    path.write_text(text, newline="\n")
+
+
 def parse_eval_script(eval_script: str) -> list[str]:
     """Parse an eval.sh script into a command list (strip shebang + set flags)."""
     return [

--- a/tests/test_write_container_text.py
+++ b/tests/test_write_container_text.py
@@ -1,0 +1,20 @@
+"""Regression for Windows CRLF poisoning files copied into Linux eval containers."""
+
+from pathlib import Path
+
+from swebench.harness.utils import write_container_text
+
+
+def test_write_container_text_keeps_lf_even_when_platform_uses_crlf(tmp_path: Path) -> None:
+    script = "#!/bin/bash\nset -euo pipefail\ncd /testbed\n"
+    patch = "diff --git a/x b/x\n+++ b/x\n+ok\n"
+    eval_file = tmp_path / "eval.sh"
+    patch_file = tmp_path / "patch.diff"
+
+    write_container_text(eval_file, script)
+    write_container_text(patch_file, patch)
+
+    assert eval_file.read_bytes() == script.encode("utf-8")
+    assert patch_file.read_bytes() == patch.encode("utf-8")
+    assert b"\r" not in eval_file.read_bytes()
+    assert b"\r" not in patch_file.read_bytes()


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #652

#### What does this implement/fix? Explain your changes.

On Windows hosts, `Path.write_text(...)` translates `\n` to `\r\n`. The harness then copies `patch.diff` and `eval.sh` into Linux eval containers, where bash rejects `set -euo pipefail` / paths with trailing `\r` and `git apply` rejects the CRLF patch — every instance grades unresolved, including gold patches.

This change writes those two container-bound files through `write_container_text()` (`newline="\n"`) so the bytes stay LF regardless of host OS. Added a unit test that asserts the written files contain no `\r`.

#### Any other comments?

Validated with `pytest tests/test_write_container_text.py` (1 passed). Full gold-patch Docker regrade was not re-run here; the issue reporter already verified that adding `newline="\n"` recovers gold resolves on Windows.
